### PR TITLE
Add/update contribution guidelines, issue/PR templates for GH Issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Expected Behavior
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+## Current Behavior
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement the addition or change -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+* Version used:
+* Browser Name and version:
+* Operating System and version (desktop or mobile):
+* Link to your project:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,41 @@
+<!-- Thank you for your contribution!
+
+     Please file this form by replacing the Markdown comments
+     with your text. If a section needs no action - remove it.
+
+     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
+     of code collaboration. Positive feedback is represented +1 from committers
+     and negative is a -1. The -1 also means veto, and needs to be addressed
+     to proceed. Once there are no objections, the PR can be merged by a
+     CouchDB committer.
+
+     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->
+
+## Overview
+
+<!-- Please give a short brief for the pull request,
+     what problem it solves or how it makes things better. -->
+
+## Testing recommendations
+
+<!-- Describe how we can test your changes.
+     Does it provides any behaviour that the end users
+     could notice? -->
+
+## GitHub issue number
+
+<!-- If this is a significant change, please file a separate issue at:
+     https://github.com/apache/couchdb-docker/issues
+     and include the number here and in commit message(s) using
+     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->
+
+## Related Pull Requests
+
+<!-- If your changes affects multiple components in different
+     repositories please put links to those pull requests here.  -->
+
+## Checklist
+
+- [ ] Code is written and works correctly;
+- [ ] Changes are covered by tests;
+- [ ] Documentation reflects the changes;

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
-YADC [![Build Status](https://travis-ci.org/klaemo/docker-couchdb.svg?branch=master)](https://travis-ci.org/klaemo/docker-couchdb)
-===
+# Semi-official Apache CouchDB Docker images [![Build Status](https://travis-ci.org/apache/couchdb-docker.svg?branch=master)](https://travis-ci.org/apache/couchdb-docker)
 
-Yet Another Dockerized CouchDB.
 Put the couch in a docker container and ship it anywhere.
 
 If you're looking for a CouchDB with SSL support you can check out [klaemo/couchdb-ssl](https://index.docker.io/u/klaemo/couchdb-ssl/)
@@ -160,9 +158,16 @@ For the `2.0-single` image, configuration is stored at `/opt/couchdb/etc/`.
 
 ## Feedback, Issues, Contributing
 
-**Please use Github issues for any questions, bugs, feature requests. :)**
-I don't get notified about comments on Docker Hub, so I might respond really late...or not at all.
+General feedback is welcome at our [user][1] or [developer][2] mailing lists.
+
+Apache CouchDB has a [CONTRIBUTING][3] file with details on how to get started
+with issue reporting or contributing to the upkeep of this project. In short,
+use GitHub Issues, do not report anything on Docker's website.
 
 ## Contributors
 
 - [@joeybaker](https://github.com/joeybaker)
+
+[1]: http://mail-archives.apache.org/mod_mbox/couchdb-user/
+[2]: http://mail-archives.apache.org/mod_mbox/couchdb-dev/
+[3]: https://github.com/apache/couchdb/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
## Overview

We're getting ready to move from JIRA to GH Issues. This PR removes references to JIRA and expands our user experience by adding or updating a CONTRIBUTING.md file and GH Issue and PR templates. It also updates the README file to reflect these changes.

## Related Pull Requests
Similar PRs are being issued in all repos officially hosted on GitHub:
* apache/couchdb
* apache/couchdb-docker
* apache/couchdb-documentation
* apache/couchdb-fauxton
* apache/couchdb-nano
* apache/couchdb-pkg