### PR TITLE
Fix 2.0-dev tags and update Docker Hub links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Put the couch in a docker container and ship it anywhere.
 
-If you're looking for a CouchDB with SSL support you can check out [klaemo/couchdb-ssl](https://index.docker.io/u/klaemo/couchdb-ssl/)
+If you're looking for a CouchDB with SSL support you can check out [klaemo/couchdb-ssl](https://hub.docker.com/r/klaemo/couchdb-ssl/)
 
 - Version (stable): `CouchDB 1.6.1`, `Erlang 17.3`
 - Version (stable): `CouchDB 2.0.0`, `Erlang 17.3`
@@ -12,7 +12,7 @@ If you're looking for a CouchDB with SSL support you can check out [klaemo/couch
 - `1`, `1.6`, `1.6.1`: CouchDB 1.6.1
 - `1-couchperuser`, `1.6-couchperuser`, `1.6.1-couchperuser`: CouchDB 1.6.1 with couchperuser plugin
 - `latest`, `2.0.0`: CouchDB 2.0 single node
-- `dev`: CouchDB 2.0 master (development version) with preconfigured dev cluster and documentation
+- `2.0-dev`: CouchDB 2.0 master (development version) with preconfigured dev cluster and documentation
 
 ## Features
 
@@ -23,7 +23,7 @@ If you're looking for a CouchDB with SSL support you can check out [klaemo/couch
 
 ## Run (2.0.0/latest)
 
-Available on the docker registry as [klaemo/couchdb:latest](https://index.docker.io/u/klaemo/couchdb/).
+Available on the docker registry as [klaemo/couchdb:latest](https://hub.docker.com/r/klaemo/couchdb/).
 This is a build of the CouchDB 2.0 release. A data volume
 is exposed on `/opt/couchdb/data`, and the node's port is exposed on `5984`.
 
@@ -83,14 +83,14 @@ This build includes the `couchperuser` plugin.
 
 ### In a developer cluster
 
-Available on the docker registry as [klaemo/couchdb:dev](https://index.docker.io/u/klaemo/couchdb/).
+Available on the docker registry as [klaemo/couchdb:2.0-dev](https://hub.docker.com/r/klaemo/couchdb/).
 This build demonstrates the CouchDB clustering features by creating a local
 cluster of a default three nodes inside the container, with a proxy in front.
 This is great for testing clustering in your local environment.
 
 ```bash
 # expose the cluster to the world
-[sudo] docker run -it -p 5984:5984 klaemo/couchdb:dev
+[sudo] docker run -it -p 5984:5984 klaemo/couchdb:2.0-dev
 
 [ * ] Setup environment ... ok
 [ * ] Ensure CouchDB is built ... ok
@@ -114,7 +114,7 @@ Time to hack! ...
 ...but you can pass arguments to the binary
 
 ```bash
-docker run -it klaemo/couchdb:dev --admin=foo:bar
+docker run -it klaemo/couchdb:2.0-dev --admin=foo:bar
 ```
 **Note:** This will overwrite the default `--with-haproxy` flag. The cluster **won't** be exposed on
 port `5984` anymore. The individual nodes listen on `15984`, `25984`, ...`x5984`. If you wish to expose
@@ -123,13 +123,13 @@ the cluster on `5984`, pass `--with-haproxy` explicitly.
 Examples:
 ```bash
 # display the available options of the couchdb startup script
-docker run --rm klaemo/couchdb:dev --help
+docker run --rm klaemo/couchdb:2.0-dev --help
 
 # Enable admin party 🎉 and expose the cluster on port 5984
-docker run -it -p 5984:5984 klaemo/couchdb:dev --with-admin-party-please --with-haproxy
+docker run -it -p 5984:5984 klaemo/couchdb:2.0-dev --with-admin-party-please --with-haproxy
 
 # Start two nodes (without proxy) exposed on port 15984 and 25984
-docker run -it -p 15984:15984 -p 25984:25984 klaemo/couchdb:dev -n 2
+docker run -it -p 15984:15984 -p 25984:25984 klaemo/couchdb:2.0-dev -n 2
 ```
 
 ## Build your own


### PR DESCRIPTION
## Overview

References to the `2.0-dev` image pointed to/mentioned the non-existent `dev` tag. I also updated links to the Docker Hub to use the current default subdomain.

## Testing recommendations

There are no observable changes.

## Checklist

- [n/a] Code is written and works correctly;
- [n/a] Changes are covered by tests;
- [x] Documentation reflects the changes;
