### PR TITLE
Add couchdb 2.1.0 docker image

### DIFF
--- a/2.1.0/Dockerfile
+++ b/2.1.0/Dockerfile
@@ -74,12 +74,6 @@ RUN buildDeps=' \
     make \
   ' \
  && apt-get update -y -qq && apt-get install -y --no-install-recommends $buildDeps \
- && curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
- && echo 'deb https://deb.nodesource.com/node_4.x jessie main' > /etc/apt/sources.list.d/nodesource.list \
- && echo 'deb-src https://deb.nodesource.com/node_4.x jessie main' >> /etc/apt/sources.list.d/nodesource.list \
- && apt-get update -y -qq \
- && apt-get install -y nodejs \
- && npm install -g grunt-cli \
  # Acquire CouchDB source code
  && cd /usr/src && mkdir couchdb \
  && curl -fSL https://dist.apache.org/repos/dist/release/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz -o couchdb.tar.gz \
@@ -93,7 +87,7 @@ RUN buildDeps=' \
  && mv /usr/src/couchdb/rel/couchdb /opt/ \
  # Cleanup build detritus
  && apt-get purge -y --auto-remove $buildDeps \
- && rm -rf /var/lib/apt/lists/* /usr/lib/node_modules /usr/src/couchdb*
+ && rm -rf /var/lib/apt/lists/* /usr/src/couchdb*
 
 # Add configuration
 COPY local.ini /opt/couchdb/etc/local.d/

--- a/2.1.0/Dockerfile
+++ b/2.1.0/Dockerfile
@@ -1,0 +1,114 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+FROM debian:jessie
+
+MAINTAINER Clemens Stolle klaemo@apache.org
+
+# Add CouchDB user account
+RUN groupadd -r couchdb && useradd -d /opt/couchdb -g couchdb couchdb
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    erlang-nox \
+    erlang-reltool \
+    haproxy \
+    libicu52 \
+    libmozjs185-1.0 \
+    openssl \
+  && rm -rf /var/lib/apt/lists/*
+
+# grab gosu for easy step-down from root and tini for signal handling
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+  && curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
+  && curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
+  && gpg --verify /usr/local/bin/gosu.asc \
+  && rm /usr/local/bin/gosu.asc \
+  && chmod +x /usr/local/bin/gosu \
+  && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
+  && curl -o /usr/local/bin/tini -fSL "https://github.com/krallin/tini/releases/download/v0.14.0/tini" \
+  && curl -o /usr/local/bin/tini.asc -fSL "https://github.com/krallin/tini/releases/download/v0.14.0/tini.asc" \
+  && gpg --verify /usr/local/bin/tini.asc \
+  && rm /usr/local/bin/tini.asc \
+  && chmod +x /usr/local/bin/tini
+
+# https://www.apache.org/dist/couchdb/KEYS
+ENV GPG_KEYS \
+  15DD4F3B8AACA54740EB78C7B7B7C53943ECCEE1 \
+  1CFBFA43C19B6DF4A0CA3934669C02FFDF3CEBA3 \
+  25BBBAC113C1BFD5AA594A4C9F96B92930380381 \
+  4BFCA2B99BADC6F9F105BEC9C5E32E2D6B065BFB \
+  5D680346FAA3E51B29DBCB681015F68F9DA248BC \
+  7BCCEB868313DDA925DF1805ECA5BCB7BB9656B0 \
+  C3F4DFAEAD621E1C94523AEEC376457E61D50B88 \
+  D2B17F9DA23C0A10991AF2E3D9EE01E47852AEE4 \
+  E0AF0A194D55C84E4A19A801CDB0C0F904F4EE9B \
+  29E4F38113DF707D722A6EF91FE9AF73118F1A7C \
+  2EC788AE3F239FA13E82D215CDE711289384AE37
+RUN set -xe \
+  && for key in $GPG_KEYS; do \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+  done
+
+ENV COUCHDB_VERSION 2.1.0
+
+# Download dev dependencies
+RUN buildDeps=' \
+    apt-transport-https \
+    gcc \
+    g++ \
+    erlang-dev \
+    libcurl4-openssl-dev \
+    libicu-dev \
+    libmozjs185-dev \
+    make \
+  ' \
+ && apt-get update -y -qq && apt-get install -y --no-install-recommends $buildDeps \
+ && curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
+ && echo 'deb https://deb.nodesource.com/node_4.x jessie main' > /etc/apt/sources.list.d/nodesource.list \
+ && echo 'deb-src https://deb.nodesource.com/node_4.x jessie main' >> /etc/apt/sources.list.d/nodesource.list \
+ && apt-get update -y -qq \
+ && apt-get install -y nodejs \
+ && npm install -g grunt-cli \
+ # Acquire CouchDB source code
+ && cd /usr/src && mkdir couchdb \
+ && curl -fSL https://dist.apache.org/repos/dist/release/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz -o couchdb.tar.gz \
+ && curl -fSL https://dist.apache.org/repos/dist/release/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz.asc -o couchdb.tar.gz.asc \
+ && gpg --verify couchdb.tar.gz.asc \
+ && tar -xzf couchdb.tar.gz -C couchdb --strip-components=1 \
+ && cd couchdb \
+ # Build the release and install into /opt
+ && ./configure --disable-docs \
+ && make release \
+ && mv /usr/src/couchdb/rel/couchdb /opt/ \
+ # Cleanup build detritus
+ && apt-get purge -y --auto-remove $buildDeps \
+ && rm -rf /var/lib/apt/lists/* /usr/lib/node_modules /usr/src/couchdb*
+
+# Add configuration
+COPY local.ini /opt/couchdb/etc/local.d/
+COPY vm.args /opt/couchdb/etc/
+
+COPY ./docker-entrypoint.sh /
+
+# Setup directories and permissions
+RUN chmod +x /docker-entrypoint.sh \
+ && mkdir /opt/couchdb/data \
+ && chown -R couchdb:couchdb /opt/couchdb/
+
+WORKDIR /opt/couchdb
+EXPOSE 5984 4369 9100
+VOLUME ["/opt/couchdb/data"]
+
+ENTRYPOINT ["tini", "--", "/docker-entrypoint.sh"]
+CMD ["/opt/couchdb/bin/couchdb"]

--- a/2.1.0/Dockerfile
+++ b/2.1.0/Dockerfile
@@ -107,7 +107,7 @@ RUN chmod +x /docker-entrypoint.sh \
  && chown -R couchdb:couchdb /opt/couchdb/
 
 WORKDIR /opt/couchdb
-EXPOSE 5984 4369 9100
+EXPOSE 5984 5986 4369 9100
 VOLUME ["/opt/couchdb/data"]
 
 ENTRYPOINT ["tini", "--", "/docker-entrypoint.sh"]

--- a/2.1.0/docker-entrypoint.sh
+++ b/2.1.0/docker-entrypoint.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+set -e
+
+if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
+	# we need to set the permissions here because docker mounts volumes as root
+	chown -R couchdb:couchdb /opt/couchdb
+
+	chmod -R 0770 /opt/couchdb/data
+
+	chmod 664 /opt/couchdb/etc/*.ini
+	chmod 664 /opt/couchdb/etc/local.d/*.ini
+	chmod 775 /opt/couchdb/etc/*.d
+
+	if [ ! -z "$NODENAME" ] && ! grep "couchdb@" /opt/couchdb/etc/vm.args; then
+		echo "-name couchdb@$NODENAME" >> /opt/couchdb/etc/vm.args
+	fi
+
+	if [ "$COUCHDB_USER" ] && [ "$COUCHDB_PASSWORD" ]; then
+		# Create admin
+		printf "[admins]\n%s = %s\n" "$COUCHDB_USER" "$COUCHDB_PASSWORD" > /opt/couchdb/etc/local.d/docker.ini
+		chown couchdb:couchdb /opt/couchdb/etc/local.d/docker.ini
+	fi
+
+	# if we don't find an [admins] section followed by a non-comment, display a warning
+	if ! grep -Pzoqr '\[admins\]\n[^;]\w+' /opt/couchdb/etc/local.d/*.ini; then
+		# The - option suppresses leading tabs but *not* spaces. :)
+		cat >&2 <<-'EOWARN'
+			****************************************************
+			WARNING: CouchDB is running in Admin Party mode.
+			         This will allow anyone with access to the
+			         CouchDB port to access your database. In
+			         Docker's default configuration, this is
+			         effectively any other container on the same
+			         system.
+			         Use "-e COUCHDB_USER=admin -e COUCHDB_PASSWORD=password"
+			         to set it in "docker run".
+			****************************************************
+		EOWARN
+	fi
+
+
+	exec gosu couchdb "$@"
+fi
+
+exec "$@"

--- a/2.1.0/local.ini
+++ b/2.1.0/local.ini
@@ -1,0 +1,8 @@
+; CouchDB Configuration Settings
+
+; Custom settings should be made in this file. They will override settings
+; in default.ini, but unlike changes made to default.ini, this file won't be
+; overwritten on server upgrade.
+
+[chttpd]
+bind_address = any

--- a/2.1.0/vm.args
+++ b/2.1.0/vm.args
@@ -1,0 +1,28 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# Ensure that the Erlang VM listens on a known port
+-kernel inet_dist_listen_min 9100
+-kernel inet_dist_listen_max 9100
+
+# Tell kernel and SASL not to log anything
+-kernel error_logger silent
+-sasl sasl_error_logger false
+
+# Use kernel poll functionality if supported by emulator
++K true
+
+# Start a pool of asynchronous IO threads
++A 16
+
+# Comment this line out to enable the interactive Erlang shell on startup
++Bd -noinput


### PR DESCRIPTION
## Overview

this PR adjusts the `2.0.0` setup to build `2.1.0`

## Testing recommendations

```
$ cd 2.1.0
$ docker build -t couchdb:2.1.0 .
```
