### PR TITLE
Make secret configurable via environment

### DIFF
--- a/2.1.0/docker-entrypoint.sh
+++ b/2.1.0/docker-entrypoint.sh
@@ -35,8 +35,8 @@ if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
 
 	if [ "$COUCHDB_SECRET" ]; then
 		# Set secret
-		printf "[couch_httpd_auth]\nsecret = %s\n" "$COUCHDB_SECRET" > /opt/couchdb/etc/local.d/secret.ini
-		chown couchdb:couchdb /opt/couchdb/etc/local.d/secret.ini
+		printf "[couch_httpd_auth]\nsecret = %s\n" "$COUCHDB_SECRET" >> /opt/couchdb/etc/local.d/docker.ini
+		chown couchdb:couchdb /opt/couchdb/etc/local.d/docker.ini
 	fi
 
 	# if we don't find an [admins] section followed by a non-comment, display a warning

--- a/2.1.0/docker-entrypoint.sh
+++ b/2.1.0/docker-entrypoint.sh
@@ -33,6 +33,12 @@ if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
 		chown couchdb:couchdb /opt/couchdb/etc/local.d/docker.ini
 	fi
 
+	if [ "$COUCHDB_SECRET" ]; then
+		# Set secret
+		printf "[couch_httpd_auth]\nsecret = %s\n" "$COUCHDB_SECRET" > /opt/couchdb/etc/local.d/secret.ini
+		chown couchdb:couchdb /opt/couchdb/etc/local.d/secret.ini
+	fi
+
 	# if we don't find an [admins] section followed by a non-comment, display a warning
 	if ! grep -Pzoqr '\[admins\]\n[^;]\w+' /opt/couchdb/etc/local.d/*.ini; then
 		# The - option suppresses leading tabs but *not* spaces. :)


### PR DESCRIPTION
## Overview

This applies the changes mentioned in #9. Hopefully this makes the Dockerfile ready to be released on docker-hub.

## Testing recommendations

This can be tested by running a container based on the image and inspecting it with `docker exec` to verify that the `etc/local.d/secret.ini` file is successfully injected.

## GitHub issue number

https://github.com/apache/couchdb-docker/issues/9

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
