### PR TITLE
Allow Erlang distribution over 9100-9200 (2.1.0 only)

### DIFF
--- a/2.1.0/Dockerfile
+++ b/2.1.0/Dockerfile
@@ -101,7 +101,7 @@ RUN chmod +x /docker-entrypoint.sh \
  && chown -R couchdb:couchdb /opt/couchdb/
 
 WORKDIR /opt/couchdb
-EXPOSE 5984 5986 4369 9100
+EXPOSE 5984 5986 4369 9100-9200
 VOLUME ["/opt/couchdb/data"]
 
 ENTRYPOINT ["tini", "--", "/docker-entrypoint.sh"]

--- a/2.1.0/vm.args
+++ b/2.1.0/vm.args
@@ -12,7 +12,7 @@
 
 # Ensure that the Erlang VM listens on a known port
 -kernel inet_dist_listen_min 9100
--kernel inet_dist_listen_max 9100
+-kernel inet_dist_listen_max 9200
 
 # Tell kernel and SASL not to log anything
 -kernel error_logger silent


### PR DESCRIPTION
Without exposing more than 1 Erlang distribution port, clusters could only be 2 nodes large.

This PR expands the Erlang port distribution to the range 9100-9200, which should be large enough for nearly all use cases.