### PR TITLE
Update with feedback from @yosifkit

### DIFF
--- a/1.6.1-couchperuser/Dockerfile
+++ b/1.6.1-couchperuser/Dockerfile
@@ -12,7 +12,7 @@
 
 FROM couchdb:1.6.1
 
-MAINTAINER Clemens Stolle klaemo@apache.org
+MAINTAINER CouchDB Developers dev@couchdb.apache.org
 
 ENV COUCHPERUSER_SHA 5d28db3272eea9619d4391b33aae6030f0319ecc54aa2a2f2b6c6a8d448f03f2
 RUN apt-get update && apt-get install -y rebar make \

--- a/1.6.1/Dockerfile
+++ b/1.6.1/Dockerfile
@@ -12,7 +12,7 @@
 
 FROM debian:jessie
 
-MAINTAINER Clemens Stolle klaemo@apache.org
+MAINTAINER CouchDB Developers dev@couchdb.apache.org
 
 # Install instructions from https://cwiki.apache.org/confluence/display/COUCHDB/Debian
 
@@ -28,19 +28,27 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     libnspr4-0d \
   && rm -rf /var/lib/apt/lists/*
 
-# grab gosu for easy step-down from root and tini for signal handling
-RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-  && curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-  && curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-  && gpg --verify /usr/local/bin/gosu.asc \
-  && rm /usr/local/bin/gosu.asc \
-  && chmod +x /usr/local/bin/gosu \
-  && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
-  && curl -o /usr/local/bin/tini -fSL "https://github.com/krallin/tini/releases/download/v0.14.0/tini" \
-  && curl -o /usr/local/bin/tini.asc -fSL "https://github.com/krallin/tini/releases/download/v0.14.0/tini.asc" \
-  && gpg --verify /usr/local/bin/tini.asc \
-  && rm /usr/local/bin/tini.asc \
-  && chmod +x /usr/local/bin/tini
+# grab gosu for easy step-down from root
+ENV GOSU_VERSION 1.10
+RUN set -x \
+        && apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
+        && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+        && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+        && export GNUPGHOME="$(mktemp -d)" \
+        && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+        && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+        && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
+        && chmod +x /usr/local/bin/gosu \
+        && gosu nobody true \
+&& apt-get purge -y --auto-remove wget
+
+# grab tini for signal handling
+ENV TINI_VERSION v0.16.1
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/local/bin/tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc /usr/local/bin/tini.asc
+RUN gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
+ && gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
+&& chmod +x /usr/local/bin/tini
 
 # https://www.apache.org/dist/couchdb/KEYS
 ENV GPG_KEYS \
@@ -75,7 +83,7 @@ RUN buildDeps=' \
   && apt-get update && apt-get install -y --no-install-recommends $buildDeps \
   && curl -fSL http://apache.osuosl.org/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz -o couchdb.tar.gz \
   && curl -fSL https://www.apache.org/dist/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz.asc -o couchdb.tar.gz.asc \
-  && gpg --verify couchdb.tar.gz.asc \
+  && gpg --batch --verify couchdb.tar.gz.asc couchdb.tar.gz \
   && mkdir -p /usr/src/couchdb \
   && tar -xzf couchdb.tar.gz -C /usr/src/couchdb --strip-components=1 \
   && cd /usr/src/couchdb \

--- a/2.1.0/Dockerfile
+++ b/2.1.0/Dockerfile
@@ -12,7 +12,7 @@
 
 FROM debian:jessie
 
-MAINTAINER Clemens Stolle klaemo@apache.org
+MAINTAINER CouchDB Developers dev@couchdb.apache.org
 
 # Add CouchDB user account
 RUN groupadd -r couchdb && useradd -d /opt/couchdb -g couchdb couchdb
@@ -28,19 +28,27 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     openssl \
   && rm -rf /var/lib/apt/lists/*
 
-# grab gosu for easy step-down from root and tini for signal handling
-RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-  && curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-  && curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-  && gpg --verify /usr/local/bin/gosu.asc \
-  && rm /usr/local/bin/gosu.asc \
-  && chmod +x /usr/local/bin/gosu \
-  && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
-  && curl -o /usr/local/bin/tini -fSL "https://github.com/krallin/tini/releases/download/v0.14.0/tini" \
-  && curl -o /usr/local/bin/tini.asc -fSL "https://github.com/krallin/tini/releases/download/v0.14.0/tini.asc" \
-  && gpg --verify /usr/local/bin/tini.asc \
-  && rm /usr/local/bin/tini.asc \
-  && chmod +x /usr/local/bin/tini
+# grab gosu for easy step-down from root
+ENV GOSU_VERSION 1.10
+RUN set -x \
+	&& apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
+	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+	&& rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu \
+	&& gosu nobody true \
+&& apt-get purge -y --auto-remove wget
+
+# grab tini for signal handling
+ENV TINI_VERSION v0.16.1
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/local/bin/tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc /usr/local/bin/tini.asc
+RUN gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
+ && gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
+&& chmod +x /usr/local/bin/tini
 
 # https://www.apache.org/dist/couchdb/KEYS
 ENV GPG_KEYS \
@@ -78,7 +86,7 @@ RUN buildDeps=' \
  && cd /usr/src && mkdir couchdb \
  && curl -fSL https://dist.apache.org/repos/dist/release/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz -o couchdb.tar.gz \
  && curl -fSL https://dist.apache.org/repos/dist/release/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz.asc -o couchdb.tar.gz.asc \
- && gpg --verify couchdb.tar.gz.asc \
+ && gpg --batch --verify couchdb.tar.gz.asc couchdb.tar.gz \
  && tar -xzf couchdb.tar.gz -C couchdb --strip-components=1 \
  && cd couchdb \
  # Build the release and install into /opt
@@ -87,7 +95,9 @@ RUN buildDeps=' \
  && mv /usr/src/couchdb/rel/couchdb /opt/ \
  # Cleanup build detritus
  && apt-get purge -y --auto-remove $buildDeps \
- && rm -rf /var/lib/apt/lists/* /usr/src/couchdb*
+ && rm -rf /var/lib/apt/lists/* /usr/src/couchdb* \
+ && mkdir /opt/couchdb/data \
+ && chown -R couchdb:couchdb /opt/couchdb
 
 # Add configuration
 COPY local.ini /opt/couchdb/etc/local.d/
@@ -96,9 +106,7 @@ COPY vm.args /opt/couchdb/etc/
 COPY ./docker-entrypoint.sh /
 
 # Setup directories and permissions
-RUN chmod +x /docker-entrypoint.sh \
- && mkdir /opt/couchdb/data \
- && chown -R couchdb:couchdb /opt/couchdb/
+RUN chown -R couchdb:couchdb /opt/couchdb/etc/local.d/ /opt/couchdb/etc/vm.args
 
 WORKDIR /opt/couchdb
 EXPOSE 5984 5986 4369 9100-9200

--- a/2.1.0/docker-entrypoint.sh
+++ b/2.1.0/docker-entrypoint.sh
@@ -13,6 +13,17 @@
 
 set -e
 
+# first arg is `-something` or `+something`
+if [ "${1#-}" != "$1" ] || [ "${1#+}" != "$1" ]; then
+	set -- /opt/couchdb/bin/couchdb "$@"
+fi
+
+# first arg is the bare word `couchdb`
+if [ "$1" = 'couchdb' ]; then
+	shift
+	set -- /opt/couchdb/bin/couchdb "$@"
+fi
+
 if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
 	# we need to set the permissions here because docker mounts volumes as root
 	chown -R couchdb:couchdb /opt/couchdb

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -12,7 +12,7 @@
 
 FROM debian:jessie
 
-MAINTAINER Clemens Stolle klaemo@apache.org
+MAINTAINER CouchDB Developers dev@couchdb.apache.org
 
 ENV COUCHDB_VERSION master
 


### PR DESCRIPTION
Includes the following feedback from @yosifkit :

* Permission/ownership changes occur as often as possible in the layer in which the files are created to aid some Docker graph drivers
* Allow for simplified invocation. Any of the following work to specify additional CLI arguments:
  * `docker run couchdb:2.1.0 /opt/couchdb/bin/couchdb +A 16`
  * `docker run couchdb:2.1.0 couchdb +A 16`
  * `docker run couchdb:2.1.0 +A 16`
  * `docker run couchdb:2.1.0 -couch_ini /path/to/my/couch.ini ....`
* `gpg --verify` replaced with `gpg --batch --verify` everywhere.
