### PR TITLE
Bind node-local port to all container interfaces

### DIFF
--- a/2.1.0/local.ini
+++ b/2.1.0/local.ini
@@ -6,3 +6,6 @@
 
 [chttpd]
 bind_address = any
+
+[httpd]
+bind_address = any


### PR DESCRIPTION
Node-local port (5986) was still bound to `localhost`, meaning it could not be forwarded outside of the container. This fixes that.