### PR TITLE
Revert some changes for clustering

### DIFF
--- a/2.1.0/Dockerfile
+++ b/2.1.0/Dockerfile
@@ -109,7 +109,7 @@ COPY ./docker-entrypoint.sh /
 RUN chown -R couchdb:couchdb /opt/couchdb/etc/local.d/ /opt/couchdb/etc/vm.args
 
 WORKDIR /opt/couchdb
-EXPOSE 5984 5986 4369 9100-9200
+EXPOSE 5984 4369 9100
 VOLUME ["/opt/couchdb/data"]
 
 ENTRYPOINT ["tini", "--", "/docker-entrypoint.sh"]

--- a/2.1.0/vm.args
+++ b/2.1.0/vm.args
@@ -12,7 +12,7 @@
 
 # Ensure that the Erlang VM listens on a known port
 -kernel inet_dist_listen_min 9100
--kernel inet_dist_listen_max 9200
+-kernel inet_dist_listen_max 9100
 
 # Tell kernel and SASL not to log anything
 -kernel error_logger silent

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ The node will also start in [admin party mode](http://guide.couchdb.org/draft/se
 Note that you can also use the NODENAME environment variable to set the name of the CouchDB node inside the container.
 Once running, you can visit the new admin interface at `http://dockerhost:5984/_utils/`
 
+Note also that port 5986 is not exposed, as this can present *significant* security risks. We recommend either connecting to the node directly to access this port, via `docker exec -it <instance> /bin/bash` and accessing port 5986, or use of `--expose 5986` when launching the container, but **ONLY** if you do not expose this port publicly.
+
 ## Run (1.6.1)
 
 Available as an official image on Docker Hub as [apache/couchdb:1.6.1](https://hub.docker.com/r/apache/couchdb/)


### PR DESCRIPTION
Port 5986 does not need to be exposed, can be accessed in other ways
as described in the README.

Port range for inet_dist_listen must be one port per erlang node.
Since Docker runs a single VM per container, a single value here is
sufficient.