### PR TITLE
Add http port and bind address environment options for 2.1.1

### DIFF
--- a/2.1.1/docker-entrypoint.sh
+++ b/2.1.1/docker-entrypoint.sh
@@ -50,6 +50,9 @@ if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
 		chown couchdb:couchdb /opt/couchdb/etc/local.d/docker.ini
 	fi
 
+	printf "[chttpd]\nport = %s\nbind_address = %s\n" ${COUCHDB_HTTP_PORT:=5984} ${COUCHDB_HTTP_BIND_ADDRESS:=0.0.0.0} > /opt/couchdb/etc/local.d/bind_address.ini
+	chown couchdb:couchdb /opt/couchdb/etc/local.d/bind_address.ini
+
 	# if we don't find an [admins] section followed by a non-comment, display a warning
 	if ! grep -Pzoqr '\[admins\]\n[^;]\w+' /opt/couchdb/etc/local.d/*.ini; then
 		# The - option suppresses leading tabs but *not* spaces. :)


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

This adds the ability to set `COUCHDB_HTTP_PORT` and `COUCHDB_HTTP_BIND_ADDRESS` in 2.1.1 - I needed this for `--net=host`

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

Run the original docker image with `-e COUCHDB_HTTP_PORT=15984 -e COUCHDB_HTTP_BIND_ADDRESS=127.0.0.2` without this addition in `docker-entrypoint.sh`. observe the port and bind address are incorrect. Use this PR and verify correct

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-docker/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

N/A

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->


N/A

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;