### PR TITLE
Change nodename to be node1@<nodename> to be in line with cluster wizard

### DIFF
--- a/2.1.1/docker-entrypoint.sh
+++ b/2.1.1/docker-entrypoint.sh
@@ -34,8 +34,8 @@ if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
 	chmod 664 /opt/couchdb/etc/local.d/*.ini
 	chmod 775 /opt/couchdb/etc/*.d
 
-	if [ ! -z "$NODENAME" ] && ! grep "couchdb@" /opt/couchdb/etc/vm.args; then
-		echo "-name couchdb@$NODENAME" >> /opt/couchdb/etc/vm.args
+	if [ ! -z "$NODENAME" ] && ! grep "node1@" /opt/couchdb/etc/vm.args; then
+		echo "-name node1@$NODENAME" >> /opt/couchdb/etc/vm.args
 	fi
 
 	if [ "$COUCHDB_USER" ] && [ "$COUCHDB_PASSWORD" ]; then


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

The CouchDB cluster wizard uses `node1@<nodename>` when setting up a cluster. The environment variable `NODENAME` that gets set inside `vm.args` uses `couchdb@<nodename>`, which causes the cluster setup to fail

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

Test setting up a cluster with `-e NODENAME=<nodename>` on a clustered system and note that it won't work. Use this PR and the cluster setup works

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-docker/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

N/A

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

N/A

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;