### PR TITLE
Remove haproxy from production image

### DIFF
--- a/2.1.1/Dockerfile
+++ b/2.1.1/Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     curl \
     erlang-nox \
     erlang-reltool \
-    haproxy \
     libicu52 \
     libmozjs185-1.0 \
     openssl \


### PR DESCRIPTION
HAProxy is included in the "dev-cluster" image to proxy requests to the three nodes deployed via that image. The production image runs a single CouchDB instance in each image and does not need or want a proxy server in the image.

Closes #56