### PR TITLE
Use 5984:5984 as couchdb uid:gid, closes #53

### DIFF
--- a/1.7.1/Dockerfile
+++ b/1.7.1/Dockerfile
@@ -16,7 +16,7 @@ MAINTAINER CouchDB Developers dev@couchdb.apache.org
 
 # Install instructions from https://cwiki.apache.org/confluence/display/COUCHDB/Debian
 
-RUN groupadd -r couchdb && useradd -d /var/lib/couchdb -g couchdb couchdb
+RUN groupadd -g 5984 -r couchdb && useradd -u 5984 -d /opt/couchdb -g couchdb couchdb
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/2.1.1/Dockerfile
+++ b/2.1.1/Dockerfile
@@ -15,7 +15,7 @@ FROM debian:jessie
 MAINTAINER CouchDB Developers dev@couchdb.apache.org
 
 # Add CouchDB user account
-RUN groupadd -r couchdb && useradd -d /opt/couchdb -g couchdb couchdb
+RUN groupadd -g 5984 -r couchdb && useradd -u 5984 -d /opt/couchdb -g couchdb couchdb
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -16,7 +16,7 @@ MAINTAINER CouchDB Developers dev@couchdb.apache.org
 
 ENV COUCHDB_VERSION master
 
-RUN groupadd -r couchdb && useradd -d /usr/src/couchdb -g couchdb couchdb
+RUN groupadd -g 5984 -r couchdb && useradd -u 5984 -d /opt/couchdb -g couchdb couchdb
 
 # download dependencies
 RUN apt-get update -y -qq && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Overview

Transition to a fixed uid and gid of 5984 (couchdb's default port) for the `couchdb` user.

## Testing recommendations

Start the image, launch a bash shell into it and verify the uid and gid under `/etc/passwd` and `/etc/group`.

## GitHub issue number

Closes #53

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [X] Documentation reflects the changes;

/cc @kocolosk 