### PR TITLE
Ability to change log level by passing COUCHDB_LOG_LEVEL

### DIFF
--- a/1.7.1/docker-entrypoint.sh
+++ b/1.7.1/docker-entrypoint.sh
@@ -36,6 +36,12 @@ if [ "$1" = 'couchdb' ]; then
 		chown couchdb:couchdb /usr/local/etc/couchdb/local.d/docker.ini
 	fi
 
+	if [ "$COUCHDB_LOG_LEVEL" ]; then
+		# Set log level
+		printf "[log]\nlevel = %s\n" "$COUCHDB_LOG_LEVEL" >> /usr/local/etc/couchdb/local.d/docker.ini
+		chown couchdb:couchdb /usr/local/etc/couchdb/local.d/docker.ini
+	fi
+
 	printf "[httpd]\nport = %s\nbind_address = %s\n" ${COUCHDB_HTTP_PORT:=5984} ${COUCHDB_HTTP_BIND_ADDRESS:=0.0.0.0} > /usr/local/etc/couchdb/local.d/bind_address.ini
 	chown couchdb:couchdb /usr/local/etc/couchdb/local.d/bind_address.ini
 

--- a/2.1.1/docker-entrypoint.sh
+++ b/2.1.1/docker-entrypoint.sh
@@ -50,6 +50,12 @@ if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
 		chown couchdb:couchdb /opt/couchdb/etc/local.d/docker.ini
 	fi
 
+	if [ "$COUCHDB_LOG_LEVEL" ]; then
+		# Set log level
+		printf "[log]\nlevel = %s\n" "$COUCHDB_LOG_LEVEL" >> /opt/couchdb/etc/local.d/docker.ini
+		chown couchdb:couchdb /opt/couchdb/etc/local.d/docker.ini
+	fi
+
 	# if we don't find an [admins] section followed by a non-comment, display a warning
 	if ! grep -Pzoqr '\[admins\]\n[^;]\w+' /opt/couchdb/etc/default.d/*.ini /opt/couchdb/etc/local.d/*.ini; then
 		# The - option suppresses leading tabs but *not* spaces. :)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ In addition, a few environment variables are provided to set very common paramet
 
 * `COUCHDB_USER` and `COUCHDB_PASSWORD` will create an ini-file based local admin user with the given username and password in the file `/opt/couchdb/etc/local.d/docker.ini`.
 * `COUCHDB_SECRET` will set the CouchDB shared cluster secret value, in the file `/opt/couchdb/etc/local.d/docker.ini`.
+* `COUCHDB_LOG_LEVEL` will set the specified log level, in the file `/opt/couchdb/etc/local.d/docker.ini`.
 * `NODENAME` will set the name of the CouchDB node inside the container to `couchdb@${NODENAME}`, in the file `/opt/couchdb/etc/vm.args`. This is used for clustering purposes and can be ignored for single-node setups.
 
 If other configuration settings are desired, externally mount `/opt/couchdb/etc` and provide `.ini` configuration files under the `/opt/couchdb/etc/local.d` directory.

--- a/dev/docker-entrypoint.sh
+++ b/dev/docker-entrypoint.sh
@@ -49,6 +49,12 @@ if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
 		chown -f couchdb:couchdb /opt/couchdb/etc/local.d/docker.ini || true
 	fi
 
+	if [ "$COUCHDB_LOG_LEVEL" ]; then
+		# Set log level
+		printf "[log]\nlevel = %s\n" "$COUCHDB_LOG_LEVEL" >> /opt/couchdb/etc/local.d/docker.ini
+		chown couchdb:couchdb /opt/couchdb/etc/local.d/docker.ini
+	fi
+
 	# if we don't find an [admins] section followed by a non-comment, display a warning
 	if ! grep -Pzoqr '\[admins\]\n[^;]\w+' /opt/couchdb/etc/local.d/*.ini; then
 		# The - option suppresses leading tabs but *not* spaces. :)


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
Ability to change log level by passing COUCHDB_LOG_LEVEL environment variable to docker run command.

## Testing recommendations
`docker run -it -e COUCHDB_LOG_LEVEL=debug couchdb:2.1.1`

## Checklist

- [X] Code is written and works correctly;
- [NA] Changes are covered by tests;
- [X] Documentation reflects the changes;
