### PR TITLE
Support multi-arch image building for couchdb docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,6 @@ env:
   - RELEASE=dev-cluster
 
 script:
-  - docker build -t couchdb:$RELEASE $RELEASE
+  - make build VERSION=$RELEASE
+  - make build ARCH=ppc64le
   - docker run -d -p 5984:5984 couchdb:$RELEASE && sleep 10 && curl http://localhost:5984

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,5 @@ env:
   - RELEASE=dev-cluster
 
 script:
-  - make build VERSION=$RELEASE
-  - make build ARCH=ppc64le
-  - docker run -d -p 5984:5984 couchdb:$RELEASE && sleep 10 && curl http://localhost:5984
+  - make build VERSION=$RELEASE ARCH=ppc64le configure_options="--disable-fauxton --disable-docs"
+  - make build VERSION=$RELEASE configure_options="--disable-fauxton --disable-docs" && docker run -d -p 5984:5984 couchdb:$RELEASE && sleep 10 && curl http://localhost:5984

--- a/1.7.1-couchperuser/Dockerfile.crossbuild
+++ b/1.7.1-couchperuser/Dockerfile.crossbuild
@@ -1,0 +1,27 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+FROM couchdb:1.7.1
+
+MAINTAINER CouchDB Developers dev@couchdb.apache.org
+
+ENV COUCHPERUSER_SHA 5d28db3272eea9619d4391b33aae6030f0319ecc54aa2a2f2b6c6a8d448f03f2
+RUN apt-get update && apt-get install -y rebar make \
+ && mkdir -p /usr/local/lib/couchdb/plugins/couchperuser \
+ && cd /usr/local/lib/couchdb/plugins \
+ && curl -L -o couchperuser.tar.gz https://github.com/etrepum/couchperuser/archive/1.1.0.tar.gz \
+ && echo "$COUCHPERUSER_SHA *couchperuser.tar.gz" | sha256sum -c - \
+ && tar -xzf couchperuser.tar.gz -C couchperuser --strip-components=1 \
+ && rm couchperuser.tar.gz \
+ && cd couchperuser \
+ && make \
+ && apt-get purge -y --auto-remove rebar make

--- a/1.7.1-couchperuser/Makefile
+++ b/1.7.1-couchperuser/Makefile
@@ -1,0 +1,56 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+.PHONY: build
+ARCH ?= amd64
+VERSION ?= 1.7.1-couchperuser
+QEMUVERSION=v2.9.1
+TEMP_DIR:=$(shell mktemp -d)
+BUILD_IMAGE ?= couchdb-$(ARCH)
+
+
+ifeq ($(ARCH),amd64)
+	BASEIMAGE?=couchdb:1.7.1
+endif
+
+ifeq ($(ARCH),ppc64le)
+	BASEIMAGE?=couchdb-ppc64le:1.7.1
+        QEMUARCH=ppc64le
+endif
+
+build:
+
+ifeq ($(ARCH),amd64)
+	cp ./* $(TEMP_DIR)
+	cat Dockerfile.crossbuild \
+                | sed "s|BASEIMAGE|$(BASEIMAGE)|g" \
+                | sed "/CROSS_BUILD_COPY/d" \
+                > $(TEMP_DIR)/Dockerfile.crossbuild
+	# We just build it using the usual process.
+	docker build -t couchdb:$(VERSION) -f $(TEMP_DIR)/Dockerfile.crossbuild $(TEMP_DIR)
+	rm -rf $(TEMP_DIR)
+
+else
+	cp ./* $(TEMP_DIR)
+	cat Dockerfile.crossbuild \
+ 	        | sed "s|BASEIMAGE|$(BASEIMAGE)|g" \
+                | sed "s|ARCH|$(QEMUARCH)|g" \
+                > $(TEMP_DIR)/Dockerfile.crossbuild
+	docker run --rm --privileged multiarch/qemu-user-static:register --reset
+	curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/$(QEMUVERSION)/x86_64_qemu-$(QEMUARCH)-static.tar.gz | tar -xz -C $(TEMP_DIR)
+	# This gosu command is not necessary to run when we are building the image. Hence drop it.
+	sed -e "/gosu nobody true; /d" -e "s/CROSS_BUILD_//g" $(TEMP_DIR)/Dockerfile.crossbuild > $(TEMP_DIR)/Dockerfile.crossbuild.tmp
+	mv $(TEMP_DIR)/Dockerfile.crossbuild.tmp $(TEMP_DIR)/Dockerfile.crossbuild
+	docker build -t $(BUILD_IMAGE):$(VERSION) -f $(TEMP_DIR)/Dockerfile.crossbuild $(TEMP_DIR)
+	rm -rf $(TEMP_DIR)
+
+endif

--- a/1.7.1/Dockerfile.crossbuild
+++ b/1.7.1/Dockerfile.crossbuild
@@ -1,0 +1,124 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+FROM BASEIMAGE
+MAINTAINER CouchDB Developers dev@couchdb.apache.org
+
+CROSS_BUILD_COPY qemu-ARCH-static /usr/bin/
+
+# Install instructions from https://cwiki.apache.org/confluence/display/COUCHDB/Debian
+
+RUN groupadd -g 5984 -r couchdb && useradd -u 5984 -d /opt/couchdb -g couchdb couchdb
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    erlang-nox \
+    libicu52 \
+    libmozjs185-1.0 \
+    libnspr4 \
+    libnspr4-0d \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV GOSU_VERSION 1.10
+ENV TINI_VERSION 0.16.1
+RUN set -ex; \
+    \
+    apt-get update; \
+    apt-get install -y --no-install-recommends wget; \
+    rm -rf /var/lib/apt/lists/*; \
+    \
+    dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+    \
+# install gosu
+    wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$dpkgArch"; \
+    wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+    gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+    rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+    chmod +x /usr/local/bin/gosu; \
+    gosu nobody true; \
+    \
+# install tini
+    wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-$dpkgArch"; \
+    wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-$dpkgArch.asc"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7; \
+    gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini; \
+    rm -r "$GNUPGHOME" /usr/local/bin/tini.asc; \
+    chmod +x /usr/local/bin/tini; \
+    tini --version; \
+    \
+    apt-get purge -y --auto-remove wget
+
+# https://www.apache.org/dist/couchdb/KEYS
+ENV GPG_KEYS \
+  15DD4F3B8AACA54740EB78C7B7B7C53943ECCEE1 \
+  1CFBFA43C19B6DF4A0CA3934669C02FFDF3CEBA3 \
+  25BBBAC113C1BFD5AA594A4C9F96B92930380381 \
+  4BFCA2B99BADC6F9F105BEC9C5E32E2D6B065BFB \
+  5D680346FAA3E51B29DBCB681015F68F9DA248BC \
+  7BCCEB868313DDA925DF1805ECA5BCB7BB9656B0 \
+  C3F4DFAEAD621E1C94523AEEC376457E61D50B88 \
+  D2B17F9DA23C0A10991AF2E3D9EE01E47852AEE4 \
+  E0AF0A194D55C84E4A19A801CDB0C0F904F4EE9B
+RUN set -xe \
+  && for key in $GPG_KEYS; do \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+  done
+
+ENV COUCHDB_VERSION 1.7.1
+
+# download dependencies, compile and install couchdb,
+# set correct permissions, expose couchdb to the outside and disable logging to disk
+RUN buildDeps=' \
+    gcc \
+    g++ \
+    erlang-dev \
+    libcurl4-openssl-dev \
+    libicu-dev \
+    libmozjs185-dev \
+    libnspr4-dev \
+    make \
+  ' \
+  && apt-get update && apt-get install -y --no-install-recommends $buildDeps \
+  && curl -fSL https://apache.osuosl.org/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz -o couchdb.tar.gz \
+  && curl -fSL https://www.apache.org/dist/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz.asc -o couchdb.tar.gz.asc \
+  && gpg --batch --verify couchdb.tar.gz.asc couchdb.tar.gz \
+  && mkdir -p /usr/src/couchdb \
+  && tar -xzf couchdb.tar.gz -C /usr/src/couchdb --strip-components=1 \
+  && cd /usr/src/couchdb \
+  && ./configure --with-js-lib=/usr/lib --with-js-include=/usr/include/mozjs \
+  && make && make install \
+  && apt-get purge -y --auto-remove $buildDeps \
+  && rm -rf /var/lib/apt/lists/* /usr/src/couchdb /couchdb.tar.gz* \
+  && chown -R couchdb:couchdb \
+    /usr/local/lib/couchdb /usr/local/etc/couchdb \
+    /usr/local/var/lib/couchdb /usr/local/var/log/couchdb /usr/local/var/run/couchdb \
+  && chmod -R g+rw \
+    /usr/local/lib/couchdb /usr/local/etc/couchdb \
+    /usr/local/var/lib/couchdb /usr/local/var/log/couchdb /usr/local/var/run/couchdb \
+  && mkdir -p /var/lib/couchdb \
+  && sed -e 's/^bind_address = .*$/bind_address = 0.0.0.0/' -i /usr/local/etc/couchdb/default.ini \
+  && sed -e 's!/usr/local/var/log/couchdb/couch.log$!/dev/null!' -i /usr/local/etc/couchdb/default.ini
+
+COPY ./docker-entrypoint.sh /
+
+# Define mountable directories.
+VOLUME ["/usr/local/var/lib/couchdb"]
+
+EXPOSE 5984
+WORKDIR /var/lib/couchdb
+
+ENTRYPOINT ["tini", "--", "/docker-entrypoint.sh"]
+CMD ["couchdb"]

--- a/1.7.1/Makefile
+++ b/1.7.1/Makefile
@@ -1,0 +1,56 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+.PHONY: build
+ARCH ?= amd64
+VERSION ?= 1.7.1
+QEMUVERSION=v2.9.1
+TEMP_DIR:=$(shell mktemp -d)
+BUILD_IMAGE ?= couchdb-$(ARCH)
+
+
+ifeq ($(ARCH),amd64)
+	BASEIMAGE?=debian:jessie
+endif
+
+ifeq ($(ARCH),ppc64le)
+	BASEIMAGE?=ppc64le/debian:jessie
+        QEMUARCH=ppc64le
+endif
+
+build:
+
+ifeq ($(ARCH),amd64)
+	cp ./* $(TEMP_DIR)
+	cat Dockerfile.crossbuild \
+                | sed "s|BASEIMAGE|$(BASEIMAGE)|g" \
+                | sed "/CROSS_BUILD_COPY/d" \
+                > $(TEMP_DIR)/Dockerfile.crossbuild
+	# We just build it using the usual process.
+	docker build -t couchdb:$(VERSION) -f $(TEMP_DIR)/Dockerfile.crossbuild $(TEMP_DIR)
+	rm -rf $(TEMP_DIR)
+
+else
+	cp ./* $(TEMP_DIR)
+	cat Dockerfile.crossbuild \
+ 	        | sed "s|BASEIMAGE|$(BASEIMAGE)|g" \
+                | sed "s|ARCH|$(QEMUARCH)|g" \
+                > $(TEMP_DIR)/Dockerfile.crossbuild
+	docker run --rm --privileged multiarch/qemu-user-static:register --reset
+	curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/$(QEMUVERSION)/x86_64_qemu-$(QEMUARCH)-static.tar.gz | tar -xz -C $(TEMP_DIR)
+	# This gosu command is not necessary to run when we are building the image. Hence drop it.
+	sed -e "/gosu nobody true; /d" -e "s/CROSS_BUILD_//g" $(TEMP_DIR)/Dockerfile.crossbuild > $(TEMP_DIR)/Dockerfile.crossbuild.tmp
+	mv $(TEMP_DIR)/Dockerfile.crossbuild.tmp $(TEMP_DIR)/Dockerfile.crossbuild
+	docker build -t $(BUILD_IMAGE):$(VERSION) -f $(TEMP_DIR)/Dockerfile.crossbuild $(TEMP_DIR)
+	rm -rf $(TEMP_DIR)
+
+endif

--- a/2.1.1/Dockerfile.build
+++ b/2.1.1/Dockerfile.build
@@ -1,0 +1,128 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+FROM BASEIMAGE
+MAINTAINER CouchDB Developers dev@couchdb.apache.org
+
+CROSS_BUILD_COPY qemu-ARCH-static /usr/bin/
+# Add CouchDB user account
+RUN groupadd -r couchdb && useradd -d /opt/couchdb -g couchdb couchdb
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    erlang-nox \
+    libicu52 \
+    erlang-reltool \
+    libmozjs185-1.0 \
+    openssl \
+  && rm -rf /var/lib/apt/lists/*
+
+# grab gosu for easy step-down from root and tini for signal handling
+# see https://github.com/apache/couchdb-docker/pull/28#discussion_r141112407
+ENV GOSU_VERSION 1.10
+ENV TINI_VERSION 0.16.1
+RUN set -ex; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends wget; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	\
+# install gosu
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	chmod +x /usr/local/bin/gosu; \
+        gosu nobody true; \
+        \
+# install tini
+
+	wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-$dpkgArch"; \
+	wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-$dpkgArch.asc"; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7; \
+	gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini; \
+	rm -r "$GNUPGHOME" /usr/local/bin/tini.asc; \
+	chmod +x /usr/local/bin/tini; \
+	tini --version; \
+	\
+	apt-get purge -y --auto-remove wget
+
+# https://www.apache.org/dist/couchdb/KEYS
+ENV GPG_KEYS \
+  15DD4F3B8AACA54740EB78C7B7B7C53943ECCEE1 \
+  1CFBFA43C19B6DF4A0CA3934669C02FFDF3CEBA3 \
+  25BBBAC113C1BFD5AA594A4C9F96B92930380381 \
+  4BFCA2B99BADC6F9F105BEC9C5E32E2D6B065BFB \
+  5D680346FAA3E51B29DBCB681015F68F9DA248BC \
+  7BCCEB868313DDA925DF1805ECA5BCB7BB9656B0 \
+  C3F4DFAEAD621E1C94523AEEC376457E61D50B88 \
+  D2B17F9DA23C0A10991AF2E3D9EE01E47852AEE4 \
+  E0AF0A194D55C84E4A19A801CDB0C0F904F4EE9B \
+  29E4F38113DF707D722A6EF91FE9AF73118F1A7C \
+  2EC788AE3F239FA13E82D215CDE711289384AE37
+RUN set -xe \
+  && for key in $GPG_KEYS; do \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+  done
+
+ENV COUCHDB_VERSION 2.1.1
+
+# Download dev dependencies
+RUN buildDeps=' \
+    apt-transport-https \
+    gcc \
+    g++ \
+    erlang-dev \
+    libcurl4-openssl-dev \
+    libicu-dev \
+    libmozjs185-dev \
+    make \
+  ' \
+ && apt-get update -y -qq && apt-get install -y --no-install-recommends $buildDeps \
+ # Acquire CouchDB source code
+ && cd /usr/src && mkdir couchdb \
+ && curl -fSL https://dist.apache.org/repos/dist/release/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz -o couchdb.tar.gz \
+ && curl -fSL https://dist.apache.org/repos/dist/release/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz.asc -o couchdb.tar.gz.asc \
+ && gpg --batch --verify couchdb.tar.gz.asc couchdb.tar.gz \
+ && tar -xzf couchdb.tar.gz -C couchdb --strip-components=1 \
+ && cd couchdb \
+ # Build the release and install into /opt
+ && ./configure --disable-docs \
+ && make release \
+ && mv /usr/src/couchdb/rel/couchdb /opt/ \
+ # Cleanup build detritus
+ && apt-get purge -y --auto-remove $buildDeps \
+ && rm -rf /var/lib/apt/lists/* /usr/src/couchdb* \
+ && mkdir /opt/couchdb/data \
+ && chown -R couchdb:couchdb /opt/couchdb
+
+# Add configuration
+COPY local.ini /opt/couchdb/etc/local.d/
+COPY vm.args /opt/couchdb/etc/
+
+COPY ./docker-entrypoint.sh /
+
+# Setup directories and permissions
+RUN chown -R couchdb:couchdb /opt/couchdb/etc/local.d/ /opt/couchdb/etc/vm.args
+
+WORKDIR /opt/couchdb
+EXPOSE 5984 4369 9100
+VOLUME ["/opt/couchdb/data"]
+
+ENTRYPOINT ["tini", "--", "/docker-entrypoint.sh"]
+CMD ["/opt/couchdb/bin/couchdb"]

--- a/2.1.1/Dockerfile.crossbuild
+++ b/2.1.1/Dockerfile.crossbuild
@@ -32,11 +32,9 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
 ENV GOSU_VERSION 1.10
 ENV TINI_VERSION 0.16.1
 RUN set -ex; \
-	\
 	apt-get update; \
 	apt-get install -y --no-install-recommends wget; \
 	rm -rf /var/lib/apt/lists/*; \
-	\
 	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
 	\
 # install gosu

--- a/2.1.1/Dockerfile.crossbuild
+++ b/2.1.1/Dockerfile.crossbuild
@@ -15,7 +15,7 @@ MAINTAINER CouchDB Developers dev@couchdb.apache.org
 
 CROSS_BUILD_COPY qemu-ARCH-static /usr/bin/
 # Add CouchDB user account
-RUN groupadd -r couchdb && useradd -d /opt/couchdb -g couchdb couchdb
+RUN groupadd -g 5984 -r couchdb && useradd -u 5984 -d /opt/couchdb -g couchdb couchdb
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
     ca-certificates \
@@ -110,7 +110,7 @@ RUN buildDeps=' \
  && chown -R couchdb:couchdb /opt/couchdb
 
 # Add configuration
-COPY local.ini /opt/couchdb/etc/local.d/
+COPY 10-docker-default.ini /opt/couchdb/etc/default.d/
 COPY vm.args /opt/couchdb/etc/
 
 COPY ./docker-entrypoint.sh /

--- a/2.1.1/Makefile
+++ b/2.1.1/Makefile
@@ -29,21 +29,27 @@ endif
 build:
 
 ifeq ($(ARCH),amd64)
+	cp ./* $(TEMP_DIR)
+	cat Dockerfile.crossbuild \
+                | sed "s|BASEIMAGE|$(BASEIMAGE)|g" \
+                | sed "/CROSS_BUILD_COPY/d" \
+                > $(TEMP_DIR)/Dockerfile.crossbuild
 	# We just build it using the usual process.
-	docker build -t couchdb:2.1.1 .
+	docker build -t couchdb:2.1.1 -f $(TEMP_DIR)/Dockerfile.crossbuild $(TEMP_DIR)
+	rm -rf $(TEMP_DIR)
 
 else
 	cp ./* $(TEMP_DIR)
-	cat Dockerfile.build \
-			| sed "s|BASEIMAGE|$(BASEIMAGE)|g" \
-			| sed "s|ARCH|$(QEMUARCH)|g" \
-                > $(TEMP_DIR)/Dockerfile.build
+	cat Dockerfile.crossbuild \
+ 	        | sed "s|BASEIMAGE|$(BASEIMAGE)|g" \
+                | sed "s|ARCH|$(QEMUARCH)|g" \
+                > $(TEMP_DIR)/Dockerfile.crossbuild
 	docker run --rm --privileged multiarch/qemu-user-static:register --reset
 	curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/$(QEMUVERSION)/x86_64_qemu-$(QEMUARCH)-static.tar.gz | tar -xz -C $(TEMP_DIR)
 	# This gosu command is not necessary to run when we are building the image. Hence drop it.
-	sed -e "/gosu nobody true; /d" -e "s/CROSS_BUILD_//g" $(TEMP_DIR)/Dockerfile.build > $(TEMP_DIR)/Dockerfile.build.tmp
-	mv $(TEMP_DIR)/Dockerfile.build.tmp $(TEMP_DIR)/Dockerfile.build
-	docker build -t $(BUILD_IMAGE):2.1.1 -f $(TEMP_DIR)/Dockerfile.build $(TEMP_DIR)
+	sed -e "/gosu nobody true; /d" -e "s/CROSS_BUILD_//g" $(TEMP_DIR)/Dockerfile.crossbuild > $(TEMP_DIR)/Dockerfile.crossbuild.tmp
+	mv $(TEMP_DIR)/Dockerfile.crossbuild.tmp $(TEMP_DIR)/Dockerfile.crossbuild
+	docker build -t $(BUILD_IMAGE):2.1.1 -f $(TEMP_DIR)/Dockerfile.crossbuild $(TEMP_DIR)
 	rm -rf $(TEMP_DIR)
 
 endif

--- a/2.1.1/Makefile
+++ b/2.1.1/Makefile
@@ -1,0 +1,49 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+.PHONY: build
+ARCH ?= amd64
+QEMUVERSION=v2.9.1
+TEMP_DIR:=$(shell mktemp -d)
+BUILD_IMAGE ?= couchdb-$(ARCH)
+
+
+ifeq ($(ARCH),amd64)
+	BASEIMAGE?=debian:jessie
+endif
+
+ifeq ($(ARCH),ppc64le)
+	BASEIMAGE?=ppc64le/debian:jessie
+        QEMUARCH=ppc64le
+endif
+
+build:
+
+ifeq ($(ARCH),amd64)
+	# We just build it using the usual process.
+	docker build -t couchdb:2.1.1 .
+
+else
+	cp ./* $(TEMP_DIR)
+	cat Dockerfile.build \
+			| sed "s|BASEIMAGE|$(BASEIMAGE)|g" \
+			| sed "s|ARCH|$(QEMUARCH)|g" \
+                > $(TEMP_DIR)/Dockerfile.build
+	docker run --rm --privileged multiarch/qemu-user-static:register --reset
+	curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/$(QEMUVERSION)/x86_64_qemu-$(QEMUARCH)-static.tar.gz | tar -xz -C $(TEMP_DIR)
+	# This gosu command is not necessary to run when we are building the image. Hence drop it.
+	sed -e "/gosu nobody true; /d" -e "s/CROSS_BUILD_//g" $(TEMP_DIR)/Dockerfile.build > $(TEMP_DIR)/Dockerfile.build.tmp
+	mv $(TEMP_DIR)/Dockerfile.build.tmp $(TEMP_DIR)/Dockerfile.build
+	docker build -t $(BUILD_IMAGE):2.1.1 -f $(TEMP_DIR)/Dockerfile.build $(TEMP_DIR)
+	rm -rf $(TEMP_DIR)
+
+endif

--- a/Makefile
+++ b/Makefile
@@ -14,14 +14,4 @@
 VERSION ?= 2.1.1
 
 build:
-ifeq ($(VERSION), 2.1.1)
 	cd $(VERSION); make build
-endif
-
-ifeq ($(VERSION), 1.7.1)
-	docker build -t couchdb:1.7.1 1.7.1
-endif
-
-ifeq ($(VERSION), 1.7.1-couchperuser)
-	docker build -t couchdb:1.7.1-couchperuser 1.7.1-couchperuser
-endif

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+.PHONY: build
+VERSION ?= 2.1.1
+
+build:
+ifeq ($(VERSION), 2.1.1)
+	cd $(VERSION); make build
+endif
+
+ifeq ($(VERSION), 1.7.1)
+	docker build -t couchdb:1.7.1 1.7.1
+endif
+
+ifeq ($(VERSION), 1.7.1-couchperuser)
+	docker build -t couchdb:1.7.1-couchperuser 1.7.1-couchperuser
+endif

--- a/dev-cluster/Dockerfile
+++ b/dev-cluster/Dockerfile
@@ -12,7 +12,7 @@
 
 # Base layer containing dependencies needed at runtime. This layer will be
 # cached after the initial build.
-FROM debian:stretch
+FROM ubuntu:16.04
 
 MAINTAINER CouchDB Developers dev@couchdb.apache.org
 
@@ -25,7 +25,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     dirmngr \
     gnupg \
     haproxy \ 
-    libicu57 \
+    libicu55 \
     libmozjs185-1.0 \
     openssl \
     python && \
@@ -92,10 +92,7 @@ RUN pip install \
 
 # Node is special
 RUN set -ex; \
-    curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -; \
-    echo 'deb https://deb.nodesource.com/node_6.x stretch main' > /etc/apt/sources.list.d/nodesource.list; \
-    echo 'deb-src https://deb.nodesource.com/node_6.x stretch main' >> /etc/apt/sources.list.d/nodesource.list; \
-    apt-get update -y && apt-get install -y nodejs; \
+    apt-get update -y && apt-get install -y nodejs npm; \
     npm install -g grunt-cli
 
 

--- a/dev-cluster/Dockerfile.crossbuild
+++ b/dev-cluster/Dockerfile.crossbuild
@@ -12,9 +12,10 @@
 
 # Base layer containing dependencies needed at runtime. This layer will be
 # cached after the initial build.
-FROM ubuntu:16.04 as runtime
-
+FROM BASEIMAGE
 MAINTAINER CouchDB Developers dev@couchdb.apache.org
+
+CROSS_BUILD_COPY qemu-ARCH-static /usr/bin/
 
 # Add CouchDB user account
 RUN groupadd -r couchdb && useradd -d /opt/couchdb -g couchdb couchdb
@@ -24,6 +25,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     curl \
     dirmngr \
     gnupg \
+    haproxy \ 
     libicu55 \
     libmozjs185-1.0 \
     openssl \
@@ -71,9 +73,6 @@ RUN set -ex; \
   tini --version; \
   apt-get purge -y --auto-remove wget
 
-# Dependencies only needed during build time. This layer will also be cached
-FROM runtime AS build_dependencies
-
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
     apt-transport-https \
     build-essential \
@@ -104,12 +103,6 @@ RUN git clone $clone_url /usr/src/couchdb
 WORKDIR /usr/src/couchdb
 RUN ./configure
 
-# This layer performs the actual build of a relocatable, self-contained
-# release of CouchDB. It pulls down the latest changes from the remote
-# origin (because the layer above will be cached) and switches to the
-# branch specified in the build_arg (defaults to master)
-FROM build_dependencies AS build
-
 ARG checkout_branch=master
 ARG configure_options
 
@@ -117,23 +110,14 @@ WORKDIR /usr/src/couchdb/
 RUN git fetch origin \
     && git checkout $checkout_branch \
     && ./configure $configure_options \
-    && make release
-
-# This results in a single layer image (or at least skips the build stuff?)
-FROM runtime
-COPY --from=build /usr/src/couchdb/rel/couchdb /opt/couchdb
-
-# Add configuration
-COPY local.ini /opt/couchdb/etc/default.d/
-COPY vm.args /opt/couchdb/etc/
-COPY docker-entrypoint.sh /
+    && make all
 
 # Setup directories and permissions
-RUN chown -R couchdb:couchdb /opt/couchdb/etc/default.d/ /opt/couchdb/etc/vm.args
+RUN chown -R couchdb:couchdb /usr/src/couchdb
 
 WORKDIR /opt/couchdb
-EXPOSE 5984 4369 9100
-VOLUME ["/opt/couchdb/data"]
+EXPOSE 5984 15984 25984 35984
+VOLUME ["/usr/src/couchdb/dev/lib"]
 
-ENTRYPOINT ["tini", "--", "/docker-entrypoint.sh"]
-CMD ["/opt/couchdb/bin/couchdb"]
+ENTRYPOINT ["tini", "--", "/usr/src/couchdb/dev/run"]
+CMD ["--with-haproxy"]

--- a/dev-cluster/Makefile
+++ b/dev-cluster/Makefile
@@ -1,0 +1,57 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+.PHONY: build
+ARCH ?= amd64
+configure_options ?= "--disable-fauxton --disable-docs"
+VERSION ?= dev-cluster
+QEMUVERSION=v2.9.1
+TEMP_DIR:=$(shell mktemp -d)
+BUILD_IMAGE ?= couchdb-$(ARCH)
+
+
+ifeq ($(ARCH),amd64)
+	BASEIMAGE?=ubuntu:16.04
+endif
+
+ifeq ($(ARCH),ppc64le)
+	BASEIMAGE?=ppc64le/ubuntu:16.04
+        QEMUARCH=ppc64le
+endif
+
+build:
+
+ifeq ($(ARCH),amd64)
+	cp ./* $(TEMP_DIR)
+	cat Dockerfile.crossbuild \
+                | sed "s|BASEIMAGE|$(BASEIMAGE)|g" \
+                | sed "/CROSS_BUILD_COPY/d" \
+                > $(TEMP_DIR)/Dockerfile.crossbuild
+	# We just build it using the usual process.
+	docker build -t couchdb:$(VERSION) -f $(TEMP_DIR)/Dockerfile.crossbuild $(TEMP_DIR) --build-arg configure_options="$(configure_options)"
+	rm -rf $(TEMP_DIR)
+
+else
+	cp ./* $(TEMP_DIR)
+	cat Dockerfile.crossbuild \
+ 	        | sed "s|BASEIMAGE|$(BASEIMAGE)|g" \
+                | sed "s|ARCH|$(QEMUARCH)|g" \
+                > $(TEMP_DIR)/Dockerfile.crossbuild
+	docker run --rm --privileged multiarch/qemu-user-static:register --reset
+	curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/$(QEMUVERSION)/x86_64_qemu-$(QEMUARCH)-static.tar.gz | tar -xz -C $(TEMP_DIR)
+	# This gosu command is not necessary to run when we are building the image. Hence drop it.
+	sed -e "/gosu nobody true; /d" -e "s/CROSS_BUILD_//g" $(TEMP_DIR)/Dockerfile.crossbuild > $(TEMP_DIR)/Dockerfile.crossbuild.tmp
+	mv $(TEMP_DIR)/Dockerfile.crossbuild.tmp $(TEMP_DIR)/Dockerfile.crossbuild
+	docker build -t $(BUILD_IMAGE):$(VERSION) -f $(TEMP_DIR)/Dockerfile.crossbuild $(TEMP_DIR) --build-arg configure_options="$(configure_options)"
+	rm -rf $(TEMP_DIR)
+
+endif

--- a/dev/Dockerfile.crossbuild
+++ b/dev/Dockerfile.crossbuild
@@ -12,9 +12,11 @@
 
 # Base layer containing dependencies needed at runtime. This layer will be
 # cached after the initial build.
-FROM ubuntu:16.04 as runtime
+FROM BASEIMAGE as runtime
 
 MAINTAINER CouchDB Developers dev@couchdb.apache.org
+
+CROSS_BUILD_COPY qemu-ARCH-static /usr/bin/
 
 # Add CouchDB user account
 RUN groupadd -r couchdb && useradd -d /opt/couchdb -g couchdb couchdb

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -1,0 +1,57 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+.PHONY: build
+ARCH ?= amd64
+configure_options ?= "--disable-fauxton --disable-docs"
+VERSION ?= dev
+QEMUVERSION=v2.9.1
+TEMP_DIR:=$(shell mktemp -d)
+BUILD_IMAGE ?= couchdb-$(ARCH)
+
+
+ifeq ($(ARCH),amd64)
+	BASEIMAGE?=ubuntu:16.04
+endif
+
+ifeq ($(ARCH),ppc64le)
+	BASEIMAGE?=ppc64le/ubuntu:16.04
+        QEMUARCH=ppc64le
+endif
+
+build:
+
+ifeq ($(ARCH),amd64)
+	cp ./* $(TEMP_DIR)
+	cat Dockerfile.crossbuild \
+                | sed "s|BASEIMAGE|$(BASEIMAGE)|g" \
+                | sed "/CROSS_BUILD_COPY/d" \
+                > $(TEMP_DIR)/Dockerfile.crossbuild
+	# We just build it using the usual process.
+	docker build -t couchdb:$(VERSION) -f $(TEMP_DIR)/Dockerfile.crossbuild $(TEMP_DIR) --build-arg configure_options="$(configure_options)"
+	rm -rf $(TEMP_DIR)
+
+else
+	cp ./* $(TEMP_DIR)
+	cat Dockerfile.crossbuild \
+ 	        | sed "s|BASEIMAGE|$(BASEIMAGE)|g" \
+                | sed "s|ARCH|$(QEMUARCH)|g" \
+                > $(TEMP_DIR)/Dockerfile.crossbuild
+	docker run --rm --privileged multiarch/qemu-user-static:register --reset
+	curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/$(QEMUVERSION)/x86_64_qemu-$(QEMUARCH)-static.tar.gz | tar -xz -C $(TEMP_DIR)
+	# This gosu command is not necessary to run when we are building the image. Hence drop it.
+	sed -e "/gosu nobody true; /d" -e "s/CROSS_BUILD_//g" $(TEMP_DIR)/Dockerfile.crossbuild > $(TEMP_DIR)/Dockerfile.crossbuild.tmp
+	mv $(TEMP_DIR)/Dockerfile.crossbuild.tmp $(TEMP_DIR)/Dockerfile.crossbuild
+	docker build -t $(BUILD_IMAGE):$(VERSION) -f $(TEMP_DIR)/Dockerfile.crossbuild $(TEMP_DIR) --build-arg configure_options="$(configure_options)"
+	rm -rf $(TEMP_DIR)
+
+endif


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

This PR is the continuation of https://github.com/apache/couchdb-docker/pull/60 PR. As the author of that PR will not be able to conitnue the work, I am planning to take it to completion. This PR is still dependent on enabling ASF Jenkins CI for couchdb on Power. I will update the PR for Jenkins CI here as soon as I come up with a patch.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

`make build` on Power and Intel
`make build ARCH=ppc64le` on Intel and vice-verse. 

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-docker/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
