### PR TITLE
[issue #89] End of line expected in docker.ini

### DIFF
--- a/2.1.2/docker-entrypoint.sh
+++ b/2.1.2/docker-entrypoint.sh
@@ -43,14 +43,14 @@ if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
 	if [ "$COUCHDB_USER" ] && [ "$COUCHDB_PASSWORD" ]; then
 		# Create admin only if not already present
 		if ! grep -Pzoqr "\[admins\]\n$COUCHDB_USER =" /opt/couchdb/etc/local.d/*.ini; then
-			printf "[admins]\n%s = %s\n" "$COUCHDB_USER" "$COUCHDB_PASSWORD" >> /opt/couchdb/etc/local.d/docker.ini
+			printf "\n[admins]\n%s = %s\n" "$COUCHDB_USER" "$COUCHDB_PASSWORD" >> /opt/couchdb/etc/local.d/docker.ini
 		fi
 	fi
 
 	if [ "$COUCHDB_SECRET" ]; then
 		# Set secret only if not already present
 		if ! grep -Pzoqr "\[couch_httpd_auth\]\nsecret =" /opt/couchdb/etc/local.d/*.ini; then
-			printf "[couch_httpd_auth]\nsecret = %s\n" "$COUCHDB_SECRET" >> /opt/couchdb/etc/local.d/docker.ini
+			printf "\n[couch_httpd_auth]\nsecret = %s\n" "$COUCHDB_SECRET" >> /opt/couchdb/etc/local.d/docker.ini
 		fi
 	fi
 


### PR DESCRIPTION
The docker entry-point.sh (CouchDB 2.1.1) add the admin credentials passed in docker start parameter.
If you use a config file named docker.ini and forget to add a new line at the end of file, it will be add next to the last line.
Name the config file docker.ini is maybe not a good idea, but i lost time to understand this.
(Same thing for COUCHDB_SECRET)

## Expected Behavior
The last lines of docker.ini have to be 
```
[chttpd]
bind_address = 0.0.0.0;
[admins]
couchdb_user = couchdb_password
```

## Current Behavior
```
[chttpd]
bind_address = 0.0.0.0;[admins]
couchdb_user = couchdb_password
```

## Possible Solution
In docker entrypoint : 
`printf "[admins]\n%s = %s\n" "$COUCHDB_USER" "$COUCHDB_PASSWORD" >> /opt/couchdb/etc/local.d/docker.ini`
change it to :
` printf "\n[admins]\n%s = %s\n" "$COUCHDB_USER" "$COUCHDB_PASSWORD" >> /opt/couchdb/etc/local.d/docker.ini`

## Steps to Reproduce (for bugs)
1. start the docker with couchdb_user in parameters and copy or mounted config file named docker.ini
2. docker exec -it couchdb cat /opt/couchdb/etc/local.d/docker.ini

## Your Environment
* Version used: Docker version 18.03.0-ce, build 0520e24, docker-machine version 0.14.0, build 89b8332
* Browser Name and version: NC
* Operating System and version (desktop or mobile): docker-machine
* Link to your project: www.doc.fr