### PR TITLE
Use debian stretch, closes #91

### DIFF
--- a/2.1.2/Dockerfile
+++ b/2.1.2/Dockerfile
@@ -10,7 +10,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-FROM debian:jessie
+FROM debian:stretch
 
 MAINTAINER CouchDB Developers dev@couchdb.apache.org
 
@@ -22,9 +22,11 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     curl \
     erlang-nox \
     erlang-reltool \
-    libicu52 \
+    libicu57 \
     libmozjs185-1.0 \
     openssl \
+    gpg \
+    dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 # grab gosu for easy step-down from root and tini for signal handling


### PR DESCRIPTION
This gets us to Erlang 19.2, which is new enough to support apache/couchdb#1392 and useful dirty schedulers. It was time to get off of `debian:jessie` anyway.

This is also prep work for the imminent 2.2.0 release of CouchDB.