### PR TITLE
Add Cluster Parameter Variables

### DIFF
--- a/2.2.0/docker-entrypoint.sh
+++ b/2.2.0/docker-entrypoint.sh
@@ -54,6 +54,24 @@ if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
 		fi
 	fi
 
+	if ! grep -Pzoqr "\[cluster\]\n" /opt/couchdb/etc/local.d/*.ini; then
+		if [ "$COUCHDB_CLUSTER_Q" ]; then
+			APPEND+="q=$COUCHDB_CLUSTER_Q\n"
+		fi
+		if [ "$COUCHDB_CLUSTER_N" ]; then
+			APPEND+="n=$COUCHDB_CLUSTER_N\n"
+		fi
+		if [ "$COUCHDB_CLUSTER_W" ]; then
+			APPEND+="w=$COUCHDB_CLUSTER_W\n"
+		fi
+		if [ "$COUCHDB_CLUSTER_R" ]; then
+			APPEND+="r=$COUCHDB_CLUSTER_R\n"
+		fi
+		if [ ! -z "$APPEND" ]; then
+			echo -e "[cluster]\n$APPEND" >> /opt/couchdb/etc/local.d/docker.ini
+		fi
+	fi
+
 	chown -f couchdb:couchdb /opt/couchdb/etc/local.d/docker.ini || true
 
 	# if we don't find an [admins] section followed by a non-comment, display a warning

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ In addition, a few environment variables are provided to set very common paramet
 * `COUCHDB_USER` and `COUCHDB_PASSWORD` will create an ini-file based local admin user with the given username and password in the file `/opt/couchdb/etc/local.d/docker.ini`.
 * `COUCHDB_SECRET` will set the CouchDB shared cluster secret value, in the file `/opt/couchdb/etc/local.d/docker.ini`.
 * `NODENAME` will set the name of the CouchDB node inside the container to `couchdb@${NODENAME}`, in the file `/opt/couchdb/etc/vm.args`. This is used for clustering purposes and can be ignored for single-node setups.
+* `COUCHDB_CLUSTER_Q` `COUCHDB_CLUSTER_N` `COUCHDB_CLUSTER_R` and `COUCHDB_CLUSTER_W` will set the appropriate cluster settings in the file `/opt/couchdb/etc/local.d/docker.ini`.
 
 If other configuration settings are desired, externally mount `/opt/couchdb/etc` and provide `.ini` configuration files under the `/opt/couchdb/etc/local.d` directory.
 


### PR DESCRIPTION
I am using the docker image to set up nodes in for a couchdb cluster. With the `COUCHDB_CLUSTER_N`, `COUCHDB_CLUSTER_Q`, `COUCHDB_CLUSTER_R`, `COUCHDB_CLUSTER_W` variables it is more easy to (pre)configure the cluster within the `docker-compose.yml` file.

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [x] Documentation reflects the changes;
