### PR TITLE
Switch main Dockerfile to use binary Debian packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: required
 
+language: minimal
+
 # Avoid double build on PRs (See https://github.com/travis-ci/travis-ci/issues/1147)
 branches:
   only:

--- a/2.2.0/Dockerfile
+++ b/2.2.0/Dockerfile
@@ -10,40 +10,34 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-FROM debian:stretch
+FROM debian:stretch-slim
 
 MAINTAINER CouchDB Developers dev@couchdb.apache.org
 
-# Add CouchDB user account
+# Add CouchDB user account to make sure the IDs are assigned consistently
 RUN groupadd -g 5984 -r couchdb && useradd -u 5984 -d /opt/couchdb -g couchdb couchdb
 
-RUN apt-get update -y && apt-get install -y \
-        apt-transport-https \
-        ca-certificates \
-        curl \
-        dirmngr \
-        gnupg \
-        libicu57 \
-        libssl1.1 \
-        openssl \
-        python \
-    && echo "deb https://apache.bintray.com/couchdb-deb stretch main" \
-        | tee /etc/apt/sources.list.d/couchdb.list \
-    && cat /etc/apt/sources.list.d/couchdb.list \
-    && for server in $(shuf -e pgpkeys.mit.edu \
-            ha.pool.sks-keyservers.net \
-            hkp://p80.pool.sks-keyservers.net:80 \
-            pgp.mit.edu) ; do \
-        gpg --keyserver $server --recv-keys 8756C4F765C9AC3CB6B85D62379CE192D401AB61 && break || : ; \
-        done \
-    && gpg -a --export 8756C4F765C9AC3CB6B85D62379CE192D401AB61 > /etc/apt/trusted.gpg.d/couchdb.gpg.asc \
-    && apt-get update -y && apt-get install -y --no-install-recommends couch-libmozjs185-1.0 \
-    && rm -rf /var/lib/apt/lists/*
+# be sure GPG and apt-transport-https are available and functional
+RUN set -ex; \
+        apt-get update; \
+        apt-get install -y --no-install-recommends \
+                apt-transport-https \
+                ca-certificates \
+                dirmngr \
+                gnupg \
+        ; \
+        if ! command -v gpg > /dev/null; then \
+                apt-get install -y --no-install-recommends \
+                        dirmngr \
+                        gnupg \
+                ; \
+        fi ; \
+        rm -rf /var/lib/apt/lists/*
 
-# grab gosu for easy step-down from root and tini for signal handling
+# grab gosu for easy step-down from root and tini for signal handling and zombie reaping
 # see https://github.com/apache/couchdb-docker/pull/28#discussion_r141112407
-ENV GOSU_VERSION 1.10
-ENV TINI_VERSION 0.16.1
+ENV GOSU_VERSION 1.11
+ENV TINI_VERSION 0.18.0
 RUN set -ex; \
 	\
 	apt-get update; \
@@ -60,7 +54,7 @@ RUN set -ex; \
             ha.pool.sks-keyservers.net \
             hkp://p80.pool.sks-keyservers.net:80 \
             pgp.mit.edu) ; do \
-        gpg --keyserver $server --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
+        gpg --batch --keyserver $server --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
         done; \
 	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
 	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
@@ -75,81 +69,54 @@ RUN set -ex; \
             ha.pool.sks-keyservers.net \
             hkp://p80.pool.sks-keyservers.net:80 \
             pgp.mit.edu) ; do \
-        gpg --keyserver $server --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && break || : ; \
+        gpg --batch --keyserver $server --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && break || : ; \
         done; \
 	gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini; \
 	rm -rf "$GNUPGHOME" /usr/local/bin/tini.asc; \
 	chmod +x /usr/local/bin/tini; \
-	tini --version; \
-	\
-	apt-get purge -y --auto-remove wget
+	tini --version
 
-# https://www.apache.org/dist/couchdb/KEYS
-ENV GPG_KEYS \
-  15DD4F3B8AACA54740EB78C7B7B7C53943ECCEE1 \
-  1CFBFA43C19B6DF4A0CA3934669C02FFDF3CEBA3 \
-  25BBBAC113C1BFD5AA594A4C9F96B92930380381 \
-  4BFCA2B99BADC6F9F105BEC9C5E32E2D6B065BFB \
-  5D680346FAA3E51B29DBCB681015F68F9DA248BC \
-  7BCCEB868313DDA925DF1805ECA5BCB7BB9656B0 \
-  C3F4DFAEAD621E1C94523AEEC376457E61D50B88 \
-  D2B17F9DA23C0A10991AF2E3D9EE01E47852AEE4 \
-  E0AF0A194D55C84E4A19A801CDB0C0F904F4EE9B \
-  29E4F38113DF707D722A6EF91FE9AF73118F1A7C \
-  2EC788AE3F239FA13E82D215CDE711289384AE37
-RUN set -xe \
-    && for key in $GPG_KEYS; do \
-        for server in $(shuf -e pgpkeys.mit.edu \
-            ha.pool.sks-keyservers.net \
-            hkp://p80.pool.sks-keyservers.net:80 \
-            pgp.mit.edu) ; do \
-        gpg --keyserver $server --recv-keys "$key" && break || : ; \
-        done; \
-    done
+# http://docs.couchdb.org/en/latest/install/unix.html#installing-the-apache-couchdb-packages
+RUN set -xe; \
+        wget -O - https://couchdb.apache.org/repo/bintray-pubkey.asc | apt-key add -; \
+        apt-get purge -y --auto-remove wget
 
 ENV COUCHDB_VERSION 2.2.0
 
-# Download dev dependencies
-RUN buildDeps=' \
-        build-essential \
-        couch-libmozjs185-dev \
-        erlang-dev \
-        erlang-nox \ 
-        erlang-reltool \
-        libcurl4-openssl-dev \
-        libicu-dev \
-        make \
-        libssl-dev \
-    ' \
-    && apt-get update -y -qq && apt-get install -y --no-install-recommends $buildDeps \
-    # Acquire CouchDB source code
-    && cd /usr/src && mkdir couchdb \
-    && curl -fSL https://dist.apache.org/repos/dist/release/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz -o couchdb.tar.gz \
-    && curl -fSL https://dist.apache.org/repos/dist/release/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz.asc -o couchdb.tar.gz.asc \
-    && gpg --batch --verify couchdb.tar.gz.asc couchdb.tar.gz \
-    && tar -xzf couchdb.tar.gz -C couchdb --strip-components=1 \
-    && cd couchdb \
-    # Build the release and install into /opt
-    && ./configure \
-    && make release \
-    && mv /usr/src/couchdb/rel/couchdb /opt/ \
-    # Cleanup build detritus
-    && apt-get purge -y --auto-remove $buildDeps \
-    && rm -rf /var/lib/apt/lists/* /usr/src/couchdb* \
-    && mkdir /opt/couchdb/data \
-    && chown -R couchdb:couchdb /opt/couchdb
+RUN echo "deb https://apache.bintray.com/couchdb-deb stretch main" > /etc/apt/sources.list.d/couchdb.list
+
+# https://github.com/apache/couchdb-pkg/blob/master/debian/README.Debian
+RUN set -xe; \
+        apt-get update; \
+        \
+        echo "couchdb couchdb/mode select none" | debconf-set-selections; \
+# we DO want recommends this time
+        DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-held-packages \
+                couchdb="$COUCHDB_VERSION"~stretch \
+        ; \
+# Undo symlinks to /var/log and /var/lib
+        rmdir /var/lib/couchdb /var/log/couchdb; \
+        rm /opt/couchdb/data /opt/couchdb/var/log; \
+        mkdir -p /opt/couchdb/data /opt/couchdb/var/log; \
+        chown couchdb:couchdb /opt/couchdb/data /opt/couchdb/var/log; \
+        chmod 777 /opt/couchdb/data /opt/couchdb/var/log; \
+# Remove file that sets logging to a file
+        rm /opt/couchdb/etc/default.d/10-filelog.ini; \
+        rm -rf /var/lib/apt/lists/*
 
 # Add configuration
 COPY 10-docker-default.ini /opt/couchdb/etc/default.d/
 COPY vm.args /opt/couchdb/etc/
-COPY docker-entrypoint.sh /
+COPY docker-entrypoint.sh /usr/local/bin
+RUN ln -s usr/local/bin/docker-entrypoint.sh /docker-entrypoint.sh # backwards compat
+ENTRYPOINT ["tini", "--", "/docker-entrypoint.sh"]
 
 # Setup directories and permissions
 RUN chown -R couchdb:couchdb /opt/couchdb/etc/default.d/ /opt/couchdb/etc/vm.args
+VOLUME /opt/couchdb/data /opt/couchdb/etc/local.d
 
-WORKDIR /opt/couchdb
+# 5984: Main CouchDB endpoint
+# 4369: Erlang portmap daemon (epmd)
+# 9100: CouchDB cluster communication port
 EXPOSE 5984 4369 9100
-VOLUME ["/opt/couchdb/data"]
-
-ENTRYPOINT ["tini", "--", "/docker-entrypoint.sh"]
 CMD ["/opt/couchdb/bin/couchdb"]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Semi-official Apache CouchDB Docker images [![Build Status](https://travis-ci.org/apache/couchdb-docker.svg?branch=master)](https://travis-ci.org/apache/couchdb-docker)
 
-Put the couch in a docker container and ship it anywhere.
-
-- Version (stable): `CouchDB 2.2.0`, `Erlang 19.2.1`
+- Version (stable): `CouchDB 2.2.0`, `Erlang 19.3.5`
 
 ## Available tags
 
@@ -10,10 +8,10 @@ Put the couch in a docker container and ship it anywhere.
 
 ## Features
 
-* built on top of the solid and small `debian:stretch` base image
+* built on top of the solid and small `debian:stretch-slim` base image
 * exposes CouchDB on port `5984` of the container
 * runs everything as user `couchdb` (security ftw!)
-* docker volume for data
+* docker volumes for data and config
 
 ## Run
 
@@ -23,18 +21,32 @@ By default, CouchDB's HTTP interface is exposed on port `5984`. Once running, yo
 
 CouchDB uses `/opt/couchdb/data` to store its data, and is exposed as a volume.
 
+CouchDB uses `/opt/couchdb/etc/local.d` to store its configuration files, and is exposed as a volume.
+
 Here is an example launch line for a single-node CouchDB with an admin username and password of `admin` and `password`, exposed to the world on port `5984`:
 
 ```bash
-$ docker run -p 5984:5984 --volume ~/data:/opt/couchdb/data --volume ~/etc/local.d:/opt/couchdb/etc/local.d --env COUCHDB_USER=admin --env COUCHDB_PASSWORD=password apache/couchdb:2.1.1
-18:54:48.780 [info] Application lager started on node nonode@nohost
-18:54:48.780 [info] Application couch_log_lager started on node nonode@nohost
-18:54:48.780 [info] Application couch_mrview started on node nonode@nohost
-18:54:48.780 [info] Application couch_plugins started on node nonode@nohost
+$ docker run -p 5984:5984 --volume ~/data:/opt/couchdb/data --volume ~/etc/local.d:/opt/couchdb/etc/local.d --env COUCHDB_USER=admin --env COUCHDB_PASSWORD=password apache/couchdb:2.2.0
+[info] 2018-12-03T23:13:27.817076Z nonode@nohost <0.9.0> -------- Application couch_log started on node nonode@nohost
+[info] 2018-12-03T23:13:27.826886Z nonode@nohost <0.9.0> -------- Application folsom started on node nonode@nohost
+[info] 2018-12-03T23:13:27.902074Z nonode@nohost <0.9.0> -------- Application couch_stats started on node nonode@nohost
+[info] 2018-12-03T23:13:27.902263Z nonode@nohost <0.9.0> -------- Application khash started on node nonode@nohost
+[info] 2018-12-03T23:13:27.915398Z nonode@nohost <0.9.0> -------- Application couch_event started on node nonode@nohost
+[info] 2018-12-03T23:13:27.915545Z nonode@nohost <0.9.0> -------- Application hyper started on node nonode@nohost
+[info] 2018-12-03T23:13:27.926134Z nonode@nohost <0.9.0> -------- Application ibrowse started on node nonode@nohost
+[info] 2018-12-03T23:13:27.937730Z nonode@nohost <0.9.0> -------- Application ioq started on node nonode@nohost
+[info] 2018-12-03T23:13:27.937887Z nonode@nohost <0.9.0> -------- Application mochiweb started on node nonode@nohost
+[info] 2018-12-03T23:13:27.953558Z nonode@nohost <0.198.0> -------- Apache CouchDB 2.2.0 is starting.
+
+[info] 2018-12-03T23:13:27.953626Z nonode@nohost <0.199.0> -------- Starting couch_sup
+[notice] 2018-12-03T23:13:28.038617Z nonode@nohost <0.86.0> -------- config: [features] pluggable-storage-engines set to true for reason nil
+[notice] 2018-12-03T23:13:28.054010Z nonode@nohost <0.86.0> -------- config: [admins] admin set to -pbkdf2-6cc5b71480085c5b31429d1374cff8de7ec1df3a,7d366ab9d34caf8903f4f11cdaf5e65c,10 for reason nil
+[notice] 2018-12-03T23:13:28.098765Z nonode@nohost <0.86.0> -------- config: [couchdb] uuid set to bf7d73c802f7dbf9bb0cfd668dd94504 for reason nil
+[info] 2018-12-03T23:13:28.348952Z nonode@nohost <0.198.0> -------- Apache CouchDB has started. Time to relax.
 ```
 ### Detailed configuration
 
-CouchDB uses `/opt/couchdb/etc/local.d` to store its configuration. It is highly recommended to bind map this to an external directory, to persist the configuration across restarts.
+CouchDB uses `/opt/couchdb/etc/local.d` to store its configuration. It is highly recommended to use a volume or bind mount for this path to persist the configuration across restarts.
 
 CouchDB also uses `/opt/couchdb/etc/vm.args` to store Erlang runtime-specific changes. Changing these values is less common. If you need to change the epmd port, for instance, you will want to bind mount this file as well. (Note: files cannot be bind-mounted on Windows hosts.)
 
@@ -43,9 +55,9 @@ In addition, a few environment variables are provided to set very common paramet
 * `COUCHDB_USER` and `COUCHDB_PASSWORD` will create an ini-file based local admin user with the given username and password in the file `/opt/couchdb/etc/local.d/docker.ini`.
 * `COUCHDB_SECRET` will set the CouchDB shared cluster secret value, in the file `/opt/couchdb/etc/local.d/docker.ini`.
 * `NODENAME` will set the name of the CouchDB node inside the container to `couchdb@${NODENAME}`, in the file `/opt/couchdb/etc/vm.args`. This is used for clustering purposes and can be ignored for single-node setups.
-* Erlang Environment Variables like `ELR_FLAGS` will be used by Erlang itself. For a complete list have a look [here](http://erlang.org/doc/man/erl.html#environment-variables)
+* Erlang Environment Variables like `ERL_FLAGS` will be used by Erlang itself. For a complete list have a look [here](http://erlang.org/doc/man/erl.html#environment-variables)
 
-If other configuration settings are desired, externally mount `/opt/couchdb/etc` and provide `.ini` configuration files under the `/opt/couchdb/etc/local.d` directory.
+If other configuration settings are desired, externally mount the entire `/opt/couchdb/etc` path and provide `.ini` configuration files under the `/opt/couchdb/etc/local.d` directory. *Note that this will prevent you from getting important updates to the `default.ini` file when upgrading your CouchDB version. You have been warned.*
 
 For a CouchDB cluster you need to provide the `NODENAME` setting as well as the erlang cookie. Settings to Erlang can be made with the environment variable `ERL_FLAGS`, e.g. `ERL_FLAGS=-setcookie "brumbrum"`. Further information can be found [here](http://docs.couchdb.org/en/stable/cluster/setup.html).
 
@@ -57,7 +69,7 @@ You must create `_global_changes`, `_metadata`, `_replicator` and `_users` after
 
 The node will also start in [admin party mode](http://guide.couchdb.org/draft/security.html#party)!
 
-Note also that port 5986 is not exposed, as this can present *significant* security risks. We recommend either connecting to the node directly to access this port, via `docker exec -it <instance> /bin/bash` and accessing port 5986, or use of `--expose 5986` when launching the container, but **ONLY** if you do not expose this port publicly. Port 5986 is scheduled to be removed with the 3.x release series.
+Note also that port 5986 is not exposed, as this can present **significant** security risks. We recommend either connecting to the node directly to access this port, via `docker exec -it <instance> /bin/bash` and accessing port 5986, or use of `--expose 5986` when launching the container, but **ONLY** if you do not expose this port publicly. Port 5986 is scheduled to be removed in CouchDB 3.0.
 
 ## Development images
 
@@ -149,7 +161,7 @@ Apache CouchDB has a [CONTRIBUTING][3] file with details on how to get started
 with issue reporting or contributing to the upkeep of this project. In short,
 use GitHub Issues, do not report anything on Docker's website.
 
-## Contributors
+## Non-Apache CouchDB Development Team Contributors
 
 - [@klaemo](https://github.com/klaemo)
 - [@joeybaker](https://github.com/joeybaker)


### PR DESCRIPTION
## Overview

Simplify our build environment by simply relying on the pre-built Debian `.deb` packages for CouchDB, rather than installing all of the build dependencies, building CouchDB from scratch, then removing them all.

Don't Repeat Yourself.

I've also added a VOLUME definition for `/opt/couchdb/etc/local.d` since we recommend externally mounting this anyway. @kocolosk does this cause any concern for the helm/k8s stuff at all?

## Testing recommendations

Travis CI should build the image from scratch and test it on our behalf - if it's green, we're good.

## GitHub issue number

Closes #117 

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [X] Documentation reflects the changes;