### PR TITLE
Documentation updates for 2.3.0

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,9 @@
+<!-- STOP! If this is a CouchDB-specific issue - unrelated to running CouchDB
+     in Docker, file your issue here: https://github.com/apache/couchdb/issues 
+     instead!
+
+     This repository is only for CouchDB *Docker* specific issues. -->
+
 <!--- Provide a general summary of the issue in the Title above -->
 
 ## Expected Behavior


### PR DESCRIPTION
This normalises our README with the one in https://github.com/docker-library/docs/tree/master/couchdb while retaining the Apache-specific sections (dev image, maintainer upload instructions).

It also updates our issue template to warn users to file issues at apache/couchdb instead of here if they're experiencing an issue with CouchDB, not specifically with the Docker container.