### PR TITLE
Update Dockerfile

### DIFF
--- a/2.3.0/Dockerfile
+++ b/2.3.0/Dockerfile
@@ -12,7 +12,7 @@
 
 FROM debian:stretch-slim
 
-MAINTAINER CouchDB Developers dev@couchdb.apache.org
+LABEL maintainer="CouchDB Developers dev@couchdb.apache.org"
 
 # Add CouchDB user account to make sure the IDs are assigned consistently
 RUN groupadd -g 5984 -r couchdb && useradd -u 5984 -d /opt/couchdb -g couchdb couchdb


### PR DESCRIPTION
## Overview

According to the Dockerfile reference, `MAINTAINER` has been deprecated in favour of using the `LABEL` instruction. This patch updates the file to use that instruction instead. 

## Testing recommendations

Perform a standard build, then `docker inspect` the image.

Expected output (edited):

```
docker inspect apache/couchdb
```

```json
        ...
        "ContainerConfig": {
            ...
            "Labels": {
                "maintainer": "CouchDB Developers dev@couchdb.apache.org"
            }
        },
        ...
```

Expected output (filtered with `jq`):

```
docker inspect apache/couchdb | jq '.[]["ContainerConfig"]["Labels"]'
```

```json
{
  "maintainer": "CouchDB Developers dev@couchdb.apache.org"
}
```

## GitHub issue number

Fixes #126.
