### PR TITLE
Fix for initial startup time (#131)

### DIFF
--- a/2.3.0/Dockerfile
+++ b/2.3.0/Dockerfile
@@ -119,7 +119,7 @@ RUN ln -s usr/local/bin/docker-entrypoint.sh /docker-entrypoint.sh # backwards c
 ENTRYPOINT ["tini", "--", "/docker-entrypoint.sh"]
 
 # Setup directories and permissions
-RUN chown -R couchdb:couchdb /opt/couchdb/etc/default.d/ /opt/couchdb/etc/vm.args
+RUN find /opt/couchdb \! \( -user couchdb -group couchdb \) -exec chown -f couchdb:couchdb '{}' +
 VOLUME /opt/couchdb/data
 
 # 5984: Main CouchDB endpoint


### PR DESCRIPTION
## Overview
Initial startup time (first execution) on some docker hosts is >50 seconds. This is caused by updating the ownership of more than 1600 files during the first execution of an instance of this container. These files are all static in the container and could be modified at container build time instead of at runtime.

## Testing recommendations
Startup time for the container should be < 3 seconds.

## GitHub issue number
#131 

## Related Pull Requests
n/a

## Checklist
- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
