### PR TITLE
Fix for slow startup times

### DIFF
--- a/2.3.1/Dockerfile
+++ b/2.3.1/Dockerfile
@@ -122,7 +122,7 @@ RUN ln -s usr/local/bin/docker-entrypoint.sh /docker-entrypoint.sh # backwards c
 ENTRYPOINT ["tini", "--", "/docker-entrypoint.sh"]
 
 # Setup directories and permissions
-RUN chown -R couchdb:couchdb /opt/couchdb/etc/default.d/ /opt/couchdb/etc/vm.args
+RUN chown -R couchdb:couchdb /opt/couchdb
 VOLUME /opt/couchdb/data
 
 # 5984: Main CouchDB endpoint

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -146,7 +146,7 @@ COPY vm.args /opt/couchdb/etc/
 COPY docker-entrypoint.sh /
 
 # Setup directories and permissions
-RUN chown -R couchdb:couchdb /opt/couchdb/etc/default.d/ /opt/couchdb/etc/vm.args
+RUN chown -R couchdb:couchdb /opt/couchdb
 
 WORKDIR /opt/couchdb
 EXPOSE 5984 4369 9100


### PR DESCRIPTION
This changes the base couchdb image so that the find command that sets ownership to couchdb:couchdb does not have to change 1600+ files every time the container is started.

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

This allows containers based on the couchdb image to start being usable faster, as it does not have to apply new permissions on 1600+ files.

## Related Pull Requests

https://github.com/apache/couchdb-docker/issues/131
https://github.com/apache/couchdb-docker/pull/132

## Checklist

- [X] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
