### PR TITLE
Fix broken 1.7.2 build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ services:
   - docker
 
 env:
-  - RELEASES="1.7.2 1.7.2-couchperuser"
   - RELEASES=2.3.0
   - RELEASES=2.3.1
   - RELEASES=dev

--- a/1.7.2-couchperuser/Dockerfile
+++ b/1.7.2-couchperuser/Dockerfile
@@ -10,7 +10,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-FROM couchdb:1.7.2
+FROM apache/couchdb:1.7.2
 
 MAINTAINER CouchDB Developers dev@couchdb.apache.org
 

--- a/1.7.2/Dockerfile
+++ b/1.7.2/Dockerfile
@@ -91,8 +91,8 @@ RUN buildDeps=' \
     make \
   ' \
   && apt-get update && apt-get install -y --no-install-recommends $buildDeps \
-  && curl -fSL https://apache.osuosl.org/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz -o couchdb.tar.gz \
-  && curl -fSL https://www.apache.org/dist/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz.asc -o couchdb.tar.gz.asc \
+  && curl -fSL https://archive.apache.org/dist/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz -o couchdb.tar.gz \
+  && curl -fSL https://archive.apache.org/dist/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz.asc -o couchdb.tar.gz.asc \
   && gpg --batch --verify couchdb.tar.gz.asc couchdb.tar.gz \
   && mkdir -p /usr/src/couchdb \
   && tar -xzf couchdb.tar.gz -C /usr/src/couchdb --strip-components=1 \

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Semi-official Apache CouchDB Docker images [![Build Status](https://travis-ci.org/apache/couchdb-docker.svg?branch=master)](https://travis-ci.org/apache/couchdb-docker)
 
-- Version (stable): `CouchDB 2.3.0`, `Erlang 19.3.5`
+- Version (stable): `CouchDB 2.3.1`, `Erlang 19.3.5`
 
 ## Available tags
 
-- `latest`, `2.3.0`: CouchDB 2.3.0 single node (capable of running in a cluster)
+- `latest`, `2.3.1`: CouchDB 2.3.1 single node (capable of running in a cluster)
+- `2.3.0`: CouchDB 2.3.0 single node (capable of running in a cluster)
 
 # How to use this image
 


### PR DESCRIPTION
In rebuilding 1.7.2 I found a couple of inconsistencies that were leading to broken images.

Patching this allowed the builds to complete.

This is *NOT* a return to support for 1.7.2, just a quick fix to keep the builds working.