### PR TITLE
add setuptools to dev images

### DIFF
--- a/dev-cluster/Dockerfile
+++ b/dev-cluster/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     curl \
     dirmngr \
     gnupg \
-    haproxy \ 
+    haproxy \
     libicu57 \
     libmozjs185-1.0 \
     openssl && \
@@ -84,7 +84,8 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     python3 \
     libpython3-dev \
     python3-pip \
-    python3-sphinx
+    python3-sphinx \
+    python3-setuptools
 
 RUN pip3 install --upgrade \
     sphinx_rtd_theme \

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -99,7 +99,8 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     python3 \
     libpython3-dev \
     python3-pip \
-    python3-sphinx
+    python3-sphinx \
+    python3-setuptools
 
 RUN pip3 install --upgrade \
     sphinx_rtd_theme \


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Fixes the `dev` containers which were missing `setuptools` (perhaps lots in the transition to python 3).

## Testing recommendations

```
docker build -t couchdb:dev dev
docker build -t couchdb:dev-cluster dev-cluster
```

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
