### PR TITLE
dev: debian-buster, node 10, SM60

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ env:
   - RELEASES=dev-cluster
 
 script:
-  - for rel in $RELEASES; do docker build -t couchdb:$rel $rel; docker run -d --name $rel -p 5984:5984 couchdb:$rel && sleep 10 && curl http://localhost:5984 && docker kill $rel; done
+  - for rel in $RELEASES; do docker build -t couchdb:$rel $rel; docker run -d --name $rel -e COUCHDB_USER=admin -e COUCHDB_PASSWORD=password -p 5984:5984 couchdb:$rel && sleep 10 && curl http://admin:password@localhost:5984/ && docker kill $rel; done

--- a/dev-cluster/Dockerfile
+++ b/dev-cluster/Dockerfile
@@ -12,7 +12,7 @@
 
 # Base layer containing dependencies needed at runtime. This layer will be
 # cached after the initial build.
-FROM debian:stretch
+FROM debian:buster
 
 MAINTAINER CouchDB Developers dev@couchdb.apache.org
 
@@ -25,8 +25,8 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     dirmngr \
     gnupg \
     haproxy \
-    libicu57 \
-    libmozjs185-1.0 \
+    libicu63 \
+    libmozjs-60-0 \
     openssl && \
   rm -rf /var/lib/apt/lists/*
 
@@ -80,7 +80,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     git \
     libcurl4-openssl-dev \
     libicu-dev \
-    libmozjs185-dev \
+    libmozjs-60-dev \
     python3 \
     libpython3-dev \
     python3-pip \
@@ -96,8 +96,8 @@ RUN pip3 install --upgrade \
 # Node is special
 RUN set -ex; \
     curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -; \
-    echo 'deb https://deb.nodesource.com/node_8.x stretch main' > /etc/apt/sources.list.d/nodesource.list; \
-    echo 'deb-src https://deb.nodesource.com/node_8.x stretch main' >> /etc/apt/sources.list.d/nodesource.list; \
+    echo 'deb https://deb.nodesource.com/node_10.x buster main' > /etc/apt/sources.list.d/nodesource.list; \
+    echo 'deb-src https://deb.nodesource.com/node_10.x buster main' >> /etc/apt/sources.list.d/nodesource.list; \
     apt-get update -y && apt-get install -y nodejs; \
     npm install -g grunt-cli
 
@@ -106,10 +106,10 @@ RUN set -ex; \
 ARG clone_url=https://gitbox.apache.org/repos/asf/couchdb.git
 RUN git clone $clone_url /usr/src/couchdb
 WORKDIR /usr/src/couchdb
-RUN ./configure
+RUN ./configure -c --spidermonkey-version 60
 
 ARG checkout_branch=master
-ARG configure_options
+ARG configure_options="-c --spidermonkey-version 60"
 
 WORKDIR /usr/src/couchdb/
 RUN git fetch origin \

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -12,7 +12,7 @@
 
 # Base layer containing dependencies needed at runtime. This layer will be
 # cached after the initial build.
-FROM debian:stretch as runtime
+FROM debian:buster as runtime
 
 MAINTAINER CouchDB Developers dev@couchdb.apache.org
 
@@ -25,7 +25,7 @@ RUN apt-get update -y && apt-get install -y \
         curl \
         dirmngr \
         gnupg \
-        libicu57 \
+        libicu63 \
         libssl1.1 \
         openssl \
     && echo "deb https://apache.bintray.com/couchdb-deb stretch main" \
@@ -38,7 +38,7 @@ RUN apt-get update -y && apt-get install -y \
         gpg --batch --keyserver $server --recv-keys 8756C4F765C9AC3CB6B85D62379CE192D401AB61 && break || : ; \
         done \
     && gpg -a --export 8756C4F765C9AC3CB6B85D62379CE192D401AB61 > /etc/apt/trusted.gpg.d/couchdb.gpg.asc \
-    && apt-get update -y && apt-get install -y --no-install-recommends couch-libmozjs185-1.0 \
+    && apt-get update -y && apt-get install -y --no-install-recommends libmozjs-60-0 \
     && rm -rf /var/lib/apt/lists/*
 
 # grab gosu for easy step-down from root and tini for signal handling
@@ -89,7 +89,7 @@ FROM runtime AS build_dependencies
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
     build-essential \
-    couch-libmozjs185-dev \
+    libmozjs-60-dev \
     erlang-nox \
     erlang-reltool \
     erlang-dev \
@@ -111,8 +111,8 @@ RUN pip3 install --upgrade \
 # Node is special
 RUN set -ex; \
     curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -; \
-    echo 'deb https://deb.nodesource.com/node_8.x stretch main' > /etc/apt/sources.list.d/nodesource.list; \
-    echo 'deb-src https://deb.nodesource.com/node_8.x stretch main' >> /etc/apt/sources.list.d/nodesource.list; \
+    echo 'deb https://deb.nodesource.com/node_10.x buster main' > /etc/apt/sources.list.d/nodesource.list; \
+    echo 'deb-src https://deb.nodesource.com/node_10.x buster main' >> /etc/apt/sources.list.d/nodesource.list; \
     apt-get update -y && apt-get install -y nodejs; \
     npm install -g grunt-cli
 
@@ -120,7 +120,7 @@ RUN set -ex; \
 ARG clone_url=https://github.com/apache/couchdb.git
 RUN git clone $clone_url /usr/src/couchdb
 WORKDIR /usr/src/couchdb
-RUN ./configure
+RUN ./configure -c --spidermonkey-version 60
 
 # This layer performs the actual build of a relocatable, self-contained
 # release of CouchDB. It pulls down the latest changes from the remote
@@ -129,7 +129,7 @@ RUN ./configure
 FROM build_dependencies AS build
 
 ARG checkout_branch=master
-ARG configure_options
+ARG configure_options="-c --spidermonkey-version 60"
 
 WORKDIR /usr/src/couchdb/
 RUN git fetch origin \

--- a/dev/docker-entrypoint.sh
+++ b/dev/docker-entrypoint.sh
@@ -75,17 +75,17 @@ if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
         if ! grep -Pzoqr '\[admins\]\n[^;]\w+' /opt/couchdb/etc/default.d/*.ini /opt/couchdb/etc/local.d/*.ini; then
 		# The - option suppresses leading tabs but *not* spaces. :)
 		cat >&2 <<-'EOWARN'
-			****************************************************
-			WARNING: CouchDB is running in Admin Party mode.
-			         This will allow anyone with access to the
-			         CouchDB port to access your database. In
-			         Docker's default configuration, this is
-			         effectively any other container on the same
-			         system.
-			         Use "-e COUCHDB_USER=admin -e COUCHDB_PASSWORD=password"
-			         to set it in "docker run".
-			****************************************************
-		EOWARN
+*************************************************************
+ERROR: CouchDB 3.0+ will no longer run in "Admin Party"
+       mode. You *MUST* specify an admin user and
+       password, either via your own .ini file mapped
+       into the container at /opt/couchdb/etc/local.ini
+       or inside /opt/couchdb/etc/local.d, or with
+       "-e COUCHDB_USER=admin -e COUCHDB_PASSWORD=password"
+       to set it via "docker run".
+*************************************************************
+EOWARN
+		exit 1
 	fi
 
 


### PR DESCRIPTION
## Overview

* Move dev and dev-cluster build to debian-buster
  * Transition to node 10 from node 8
  * Updated libicu to match
  * Move to SM60
  * Intended for use on amd64 and ppc64le only; arm will break with SM60

## GitHub issue number

Part of #163 