### PR TITLE
Initial draft for couchdb 3.0.0-RC1 container

### DIFF
--- a/3.0.0-RC1/10-docker-default.ini
+++ b/3.0.0-RC1/10-docker-default.ini
@@ -1,0 +1,12 @@
+; CouchDB Configuration Settings
+
+; Custom settings should be made in this file. They will override settings
+; in default.ini, but unlike changes made to default.ini, this file won't be
+; overwritten on server upgrade.
+
+[chttpd]
+bind_address = any
+
+[httpd]
+bind_address = any
+

--- a/3.0.0-RC1/Dockerfile
+++ b/3.0.0-RC1/Dockerfile
@@ -1,0 +1,154 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+FROM debian:buster-slim
+
+LABEL maintainer="CouchDB Developers dev@couchdb.apache.org"
+
+# Add CouchDB user account to make sure the IDs are assigned consistently
+RUN groupadd -g 5984 -r couchdb && useradd -u 5984 -d /opt/couchdb -g couchdb couchdb
+
+# be sure GPG and apt-transport-https are available and functional
+RUN set -ex; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        ca-certificates \
+        dirmngr \
+        gnupg \
+     ; \
+    rm -rf /var/lib/apt/lists/*
+
+# grab gosu for easy step-down from root and tini for signal handling and zombie reaping
+# see https://github.com/apache/couchdb-docker/pull/28#discussion_r141112407
+ENV GOSU_VERSION 1.11
+ENV TINI_VERSION 0.18.0
+RUN set -ex; \
+    \
+    apt-get update; \
+    apt-get install -y --no-install-recommends wget; \
+    rm -rf /var/lib/apt/lists/*; \
+    \
+    dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+    \
+# install gosu
+    wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$dpkgArch"; \
+    wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    echo "disable-ipv6" >> ${GNUPGHOME}/dirmngr.conf; \
+    for server in $(shuf -e pgpkeys.mit.edu \
+        ha.pool.sks-keyservers.net \
+        hkp://p80.pool.sks-keyservers.net:80 \
+        pgp.mit.edu) ; do \
+    gpg --batch --keyserver $server --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
+    done; \
+    gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+    rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+    chmod +x /usr/local/bin/gosu; \
+    gosu nobody true; \
+    \
+# install tini
+    wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-$dpkgArch"; \
+    wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-$dpkgArch.asc"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    echo "disable-ipv6" >> ${GNUPGHOME}/dirmngr.conf; \
+    for server in $(shuf -e pgpkeys.mit.edu \
+        ha.pool.sks-keyservers.net \
+        hkp://p80.pool.sks-keyservers.net:80 \
+        pgp.mit.edu) ; do \
+    gpg --batch --keyserver $server --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && break || : ; \
+    done; \
+    gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini; \
+    rm -rf "$GNUPGHOME" /usr/local/bin/tini.asc; \
+    chmod +x /usr/local/bin/tini; \
+    apt-get purge -y --auto-remove wget; \
+    tini --version
+
+# http://docs.couchdb.org/en/latest/install/unix.html#installing-the-apache-couchdb-packages
+ENV GPG_COUCH_KEY \
+# gpg: key D401AB61: public key "Bintray (by JFrog) <bintray@bintray.com> imported
+    8756C4F765C9AC3CB6B85D62379CE192D401AB61
+RUN set -xe; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    echo "disable-ipv6" >> ${GNUPGHOME}/dirmngr.conf; \
+    for server in $(shuf -e pgpkeys.mit.edu \
+        ha.pool.sks-keyservers.net \
+        hkp://p80.pool.sks-keyservers.net:80 \
+        pgp.mit.edu) ; do \
+        gpg --batch --keyserver $server --recv-keys $GPG_COUCH_KEY && break || : ; \
+    done; \
+    gpg --batch --export $GPG_COUCH_KEY > /etc/apt/trusted.gpg.d/couchdb.gpg; \
+    command -v gpgconf && gpgconf --kill all || :; \
+    rm -rf "$GNUPGHOME"; \
+    apt-key list
+
+ENV COUCHDB_VERSION 3.0.0-RC1
+
+RUN echo "deb https://apache.bintray.com/couchdb-deb buster main" > /etc/apt/sources.list.d/couchdb.list
+
+# https://github.com/apache/couchdb-pkg/blob/master/debian/README.Debian
+RUN set -xe; \
+    apt-get update; \
+    \
+    echo "couchdb couchdb/mode select none" | debconf-set-selections; \
+# Install dependencies
+    apt-get --no-install-recommends -y install \
+        openssh-client git wget build-essential pkg-config erlang \
+        libicu-dev libmozjs185-dev libcurl4-openssl-dev\
+        python-sphinx python-pip; \
+    pip install -U pip setuptools; \
+    pip install --upgrade sphinx_rtd_theme nose requests hypothesis; \
+    wget -O - https://deb.nodesource.com/setup_12.x | bash -; \
+    apt-get install -y nodejs; \
+    rm -rf /var/lib/apt/lists/*; \
+# Download source from releases
+    mkdir -p /var/couchdb-source; \
+    git clone --branch ${COUCHDB_VERSION} https://github.com/apache/couchdb.git /var/couchdb-source; \
+    cd /var/couchdb-source; \
+    ./configure; \
+    make release
+
+# Undo symlinks to /var/log and /var/lib
+RUN set -eux; \
+    cp -r /var/couchdb-source/rel/couchdb /opt; \
+    mkdir /opt/couchdb/data; \
+    chown couchdb:couchdb /opt/couchdb/data /opt/couchdb/var/log; \
+    chmod 777 /opt/couchdb/data /opt/couchdb/var/log; \
+# Remove file that sets logging to a file
+#    rm /opt/couchdb/etc/default.d/10-filelog.ini; \
+# Check we own everything in /opt/couchdb. Matches the command in dockerfile_entrypoint.sh
+    find /opt/couchdb \! \( -user couchdb -group couchdb \) -exec chown -f couchdb:couchdb '{}' +; \
+# Setup directories and permissions for config. Technically these could be 555 and 444 respectively
+# but we keep them as 755 and 644 for consistency with CouchDB defaults and the dockerfile_entrypoint.sh.
+    find /opt/couchdb/etc -type d ! -perm 0755 -exec chmod -f 0755 '{}' +; \
+    find /opt/couchdb/etc -type f ! -perm 0644 -exec chmod -f 0644 '{}' +; \
+# only local.d needs to be writable for the docker_entrypoint.sh
+    chmod -f 0777 /opt/couchdb/etc/local.d
+# apt clean-up
+
+# Add configuration
+COPY --chown=couchdb:couchdb 10-docker-default.ini /opt/couchdb/etc/default.d/
+COPY --chown=couchdb:couchdb vm.args /opt/couchdb/etc/
+
+COPY --chown=couchdb:couchdb docker-entrypoint.sh /usr/local/bin
+RUN set -eux; \
+    chmod +x /usr/local/bin/docker-entrypoint.sh; \
+    ln -s usr/local/bin/docker-entrypoint.sh /docker-entrypoint.sh
+ENTRYPOINT ["tini", "--", "/docker-entrypoint.sh"]
+
+VOLUME /opt/couchdb/data
+
+# 5984: Main CouchDB endpoint
+# 4369: Erlang portmap daemon (epmd)
+# 9100: CouchDB cluster communication port
+EXPOSE 5984 4369 9100
+CMD ["/opt/couchdb/bin/couchdb"]

--- a/3.0.0-RC1/docker-entrypoint.sh
+++ b/3.0.0-RC1/docker-entrypoint.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+set -e
+
+# first arg is `-something` or `+something`
+if [ "${1#-}" != "$1" ] || [ "${1#+}" != "$1" ]; then
+	set -- /opt/couchdb/bin/couchdb "$@"
+fi
+
+# first arg is the bare word `couchdb`
+if [ "$1" = 'couchdb' ]; then
+	shift
+	set -- /opt/couchdb/bin/couchdb "$@"
+fi
+
+if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
+	# Check that we own everything in /opt/couchdb and fix if necessary. We also
+	# add the `-f` flag in all the following invocations because there may be
+	# cases where some of these ownership and permissions issues are non-fatal
+	# (e.g. a config file owned by root with o+r is actually fine), and we don't
+	# to be too aggressive about crashing here ...
+	find /opt/couchdb \! \( -user couchdb -group couchdb \) -exec chown -f couchdb:couchdb '{}' +
+
+	# Ensure that data files have the correct permissions. We were previously
+	# preventing any access to these files outside of couchdb:couchdb, but it
+	# turns out that CouchDB itself does not set such restrictive permissions
+	# when it creates the files. The approach taken here ensures that the
+	# contents of the datadir have the same permissions as they had when they
+	# were initially created. This should minimize any startup delay.
+	find /opt/couchdb/data -type d ! -perm 0755 -exec chmod -f 0755 '{}' +
+	find /opt/couchdb/data -type f ! -perm 0644 -exec chmod -f 0644 '{}' +
+
+	# Do the same thing for configuration files and directories. Technically
+	# CouchDB only needs read access to the configuration files as all online
+	# changes will be applied to the "docker.ini" file below, but we set 644
+	# for the sake of consistency.
+	find /opt/couchdb/etc -type d ! -perm 0755 -exec chmod -f 0755 '{}' +
+	find /opt/couchdb/etc -type f ! -perm 0644 -exec chmod -f 0644 '{}' +
+
+	if [ ! -z "$NODENAME" ] && ! grep "couchdb@" /opt/couchdb/etc/vm.args; then
+		echo "-name couchdb@$NODENAME" >> /opt/couchdb/etc/vm.args
+	fi
+
+	# Ensure that CouchDB will write custom settings in this file
+	touch /opt/couchdb/etc/local.d/docker.ini
+
+	if [ "$COUCHDB_USER" ] && [ "$COUCHDB_PASSWORD" ]; then
+		# Create admin only if not already present
+		if ! grep -Pzoqr "\[admins\]\n$COUCHDB_USER =" /opt/couchdb/etc/local.d/*.ini; then
+			printf "\n[admins]\n%s = %s\n" "$COUCHDB_USER" "$COUCHDB_PASSWORD" >> /opt/couchdb/etc/local.d/docker.ini
+		fi
+	fi
+
+	if [ "$COUCHDB_SECRET" ]; then
+		# Set secret only if not already present
+		if ! grep -Pzoqr "\[couch_httpd_auth\]\nsecret =" /opt/couchdb/etc/local.d/*.ini; then
+			printf "\n[couch_httpd_auth]\nsecret = %s\n" "$COUCHDB_SECRET" >> /opt/couchdb/etc/local.d/docker.ini
+		fi
+	fi
+
+	chown -f couchdb:couchdb /opt/couchdb/etc/local.d/docker.ini || true
+
+	# if we don't find an [admins] section followed by a non-comment, display a warning
+        if ! grep -Pzoqr '\[admins\]\n[^;]\w+' /opt/couchdb/etc/default.d/*.ini /opt/couchdb/etc/local.d/*.ini; then
+		# The - option suppresses leading tabs but *not* spaces. :)
+		cat >&2 <<-'EOWARN'
+			****************************************************
+			WARNING: CouchDB is running in Admin Party mode.
+			         This will allow anyone with access to the
+			         CouchDB port to access your database. In
+			         Docker's default configuration, this is
+			         effectively any other container on the same
+			         system.
+			         Use "-e COUCHDB_USER=admin -e COUCHDB_PASSWORD=password"
+			         to set it in "docker run".
+			****************************************************
+		EOWARN
+	fi
+
+
+	exec gosu couchdb "$@"
+fi
+
+exec "$@"
+

--- a/3.0.0-RC1/vm.args
+++ b/3.0.0-RC1/vm.args
@@ -1,0 +1,29 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# Ensure that the Erlang VM listens on a known port
+-kernel inet_dist_listen_min 9100
+-kernel inet_dist_listen_max 9100
+
+# Tell kernel and SASL not to log anything
+-kernel error_logger silent
+-sasl sasl_error_logger false
+
+# Use kernel poll functionality if supported by emulator
++K true
+
+# Start a pool of asynchronous IO threads
++A 16
+
+# Comment this line out to enable the interactive Erlang shell on startup
++Bd -noinput
+


### PR DESCRIPTION
## Overview

This container of CouchDB 3.0.0-RC1 is meant to be a replacement for stable containers. It should allow a quick replacement of the current stable container for testing purposes.

## Testing recommendations

Currently this PR is in Draft-state since i will need a little guidance to the following points:

1. Should Travis be invoked for this (the latest) RC, too?
2. The Dockerfile is based on the 3.0 Dockerfile from #166  using a manual installation as described in the INSTALL document. Therefore unnecessary may pollute the image (like the documentation - i am new to CouchDB so i have no clue what's really necessary).
3. Since an admin account will be needed now, i'd like to add two parameters for that. Does the documentation for starting CouchDB creating an initial user like in 2.3 still apply?

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
