### PR TITLE
Update Dockerfile to use `main` branch rather than master

### DIFF
--- a/dev-cluster/Dockerfile
+++ b/dev-cluster/Dockerfile
@@ -108,7 +108,7 @@ RUN git clone $clone_url /usr/src/couchdb
 WORKDIR /usr/src/couchdb
 RUN ./configure -c --spidermonkey-version 60
 
-ARG checkout_branch=master
+ARG checkout_branch=main
 ARG configure_options="-c --spidermonkey-version 60"
 
 WORKDIR /usr/src/couchdb/

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -125,10 +125,10 @@ RUN ./configure
 # This layer performs the actual build of a relocatable, self-contained
 # release of CouchDB. It pulls down the latest changes from the remote
 # origin (because the layer above will be cached) and switches to the
-# branch specified in the build_arg (defaults to master)
+# branch specified in the build_arg (defaults to main)
 FROM build_dependencies AS build
 
-ARG checkout_branch=master
+ARG checkout_branch=main
 ARG configure_options
 ARG spidermonkey_version=60
 


### PR DESCRIPTION
## Overview
Since from apache/couchdb#3224 CouchDB moved from `master` to `main` but the Dockerfile still refers default branch to be`master` and fails during the build.
<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
The changes will fix the failing dev builds.
## Checklist

- [x] Code is written and works correctly;
