### PR TITLE
Update with jfrog artifactory repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: minimal
 # Avoid double build on PRs (See https://github.com/travis-ci/travis-ci/issues/1147)
 branches:
   only:
-    - master
+    - main
 
 services:
   - docker
@@ -15,8 +15,9 @@ env:
   - RELEASES=2.3.1-ubi
   - RELEASES=3.1.1
   - RELEASES=3.1.1-ubi
-  - RELEASES=dev
-  - RELEASES=dev-cluster
+# Needs updating for fdb
+#  - RELEASES=dev
+#  - RELEASES=dev-cluster
 
 script:
   - for rel in $RELEASES; do docker build -t couchdb:$rel $rel; docker run -d --name $rel -e COUCHDB_USER=admin -e COUCHDB_PASSWORD=password -p 5984:5984 couchdb:$rel && sleep 10 && curl http://admin:password@localhost:5984/ && docker kill $rel; done

--- a/2.3.1-ubi/Dockerfile
+++ b/2.3.1-ubi/Dockerfile
@@ -31,7 +31,7 @@ LABEL maintainer="CouchDB Developers dev@couchdb.apache.org" \
       io.openshift.min-cpu="1"
 
 COPY imeyer_runit.repo /etc/yum.repos.d/imeyer_runit.repo
-COPY bintray-apache-couchdb-rpm.repo /etc/yum.repos.d/bintray-apache-couchdb-rpm.repo
+COPY couchdb.repo /etc/yum.repos.d/couchdb.repo
 
 ENV COUCHDB_VERSION 2.3.1
 
@@ -55,28 +55,10 @@ RUN set -ex; \
     microdnf clean all; \
     rm -rf /var/cache/yum
 
-# https://docs.couchdb.org/en/stable/install/unix.html
-# ENV GPG_COUCH_KEY \
-# # gpg: key D401AB61: public key "Bintray (by JFrog) <bintray@bintray.com> imported
-#        8756C4F765C9AC3CB6B85D62379CE192D401AB61
-# RUN set -xe; \
-#         export GNUPGHOME="$(mktemp -d)"; \
-#         echo "disable-ipv6" >> ${GNUPGHOME}/dirmngr.conf; \
-#         for server in $(shuf -e pgpkeys.mit.edu \
-#             ha.pool.sks-keyservers.net \
-#             hkp://p80.pool.sks-keyservers.net:80 \
-#             pgp.mit.edu) ; do \
-#                 gpg --batch --keyserver $server --recv-keys $GPG_COUCH_KEY && break || : ; \
-#         done; \
-#         gpg --batch --export $GPG_COUCH_KEY > /etc/apt/trusted.gpg.d/couchdb.gpg; \
-#         command -v gpgconf && gpgconf --kill all || :; \
-#         rm -rf "$GNUPGHOME"; \
-#         apt-key list
-
 # Install CouchDB
 RUN set -xe; \
     microdnf update --disableplugin=subscription-manager -y && rm -rf /var/cache/yum; \
-    microdnf install --enablerepo=bintray-apache-couchdb-rpm -y couchdb-2.3.1; \
+    microdnf install --enablerepo=couchdb -y couchdb-${COUCHDB_VERSION}; \
     microdnf clean all; \
     rm -rf /var/cache/yum; \
 # remove defaults that force writing logs to file

--- a/2.3.1-ubi/bintray-apache-couchdb-rpm.repo
+++ b/2.3.1-ubi/bintray-apache-couchdb-rpm.repo
@@ -1,6 +1,0 @@
-[bintray-apache-couchdb-rpm]
-name=bintray--apache-couchdb-rpm
-baseurl=http://apache.bintray.com/couchdb-rpm/el8/x86_64
-gpgcheck=0
-repo_gpgcheck=0
-enabled=1

--- a/2.3.1-ubi/couchdb.repo
+++ b/2.3.1-ubi/couchdb.repo
@@ -1,0 +1,7 @@
+[couchdb]
+name=couchdb
+baseurl=https://apache.jfrog.io/artifactory/couchdb-rpm/el$releasever/$basearch/
+gpgkey=https://couchdb.apache.org/repo/keys.asc https://couchdb.apache.org/repo/rpm-package-key.asc
+gpgcheck=1
+repo_gpgcheck=1
+enabled=1

--- a/2.3.1/Dockerfile
+++ b/2.3.1/Dockerfile
@@ -39,29 +39,31 @@ RUN set -eux; \
 
 # http://docs.couchdb.org/en/latest/install/unix.html#installing-the-apache-couchdb-packages
 ENV GPG_COUCH_KEY \
-# gpg: key D401AB61: public key "Bintray (by JFrog) <bintray@bintray.com> imported
-    8756C4F765C9AC3CB6B85D62379CE192D401AB61
-RUN set -xe; \
+# gpg: rsa8192 205-01-19 The Apache Software Foundation (Package repository signing key) <root@apache.org>
+    390EF70BB1EA12B2773962950EE62FB37A00258D
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y curl; \
     export GNUPGHOME="$(mktemp -d)"; \
     echo "disable-ipv6" >> ${GNUPGHOME}/dirmngr.conf; \
-    for server in $(shuf -e pgpkeys.mit.edu \
-        ha.pool.sks-keyservers.net \
-        hkp://p80.pool.sks-keyservers.net:80 \
-        hkps://hkps.pool.sks-keyservers.net \
-        pgp.mit.edu) ; do \
-        gpg --batch --keyserver $server --recv-keys $GPG_COUCH_KEY && break || : ; \
-    done; \
-    gpg --batch --export $GPG_COUCH_KEY > /etc/apt/trusted.gpg.d/couchdb.gpg; \
+    curl https://couchdb.apache.org/repo/keys.asc | \
+        gpg --dearmor | \
+        tee /usr/share/keyrings/couchdb-archive-keyring.gpg >/dev/null 2>&1; \
+    gpg --show-keys /usr/share/keyrings/couchdb-archive-keyring.gpg | grep -q ${GPG_COUCH_KEY}; \
     command -v gpgconf && gpgconf --kill all || :; \
     rm -rf "$GNUPGHOME"; \
-    apt-key list
+    apt-key list; \
+    apt purge -y --autoremove curl; \
+    rm -rf /var/lib/apt/lists/*
 
 ENV COUCHDB_VERSION 2.3.1-1
 
-RUN echo "deb https://apache.bintray.com/couchdb-deb buster main" > /etc/apt/sources.list.d/couchdb.list
+RUN . /etc/os-release; \
+    echo "deb [signed-by=/usr/share/keyrings/couchdb-archive-keyring.gpg] https://apache.jfrog.io/artifactory/couchdb-deb/ ${VERSION_CODENAME} main" | \
+        tee /etc/apt/sources.list.d/couchdb.list >/dev/null
 
 # https://github.com/apache/couchdb-pkg/blob/master/debian/README.Debian
-RUN set -xe; \
+RUN set -eux; \
     apt-get update; \
     \
     echo "couchdb couchdb/mode select none" | debconf-set-selections; \

--- a/3.1.1-ubi-clouseau/Dockerfile
+++ b/3.1.1-ubi-clouseau/Dockerfile
@@ -49,9 +49,9 @@ LABEL maintainer="CouchDB Developers dev@couchdb.apache.org" \
       io.openshift.min-cpu="1"
 
 COPY imeyer_runit.repo /etc/yum.repos.d/imeyer_runit.repo
-COPY bintray-apache-couchdb-rpm.repo /etc/yum.repos.d/bintray-apache-couchdb-rpm.repo
+COPY couchdb.repo /etc/yum.repos.d/couchdb.repo
 
-ENV COUCHDB_VERSION 3.1.1 \
+ENV COUCHDB_VERSION=3.1.1 \
     CLOUSEAU_VERSION=${CLOUSEAU_VERSION} \
     JAVA_MAJOR_VERSION=8 \
     JAVA_HOME=/usr/lib/jvm/jre-1.8.0 \
@@ -78,28 +78,10 @@ RUN set -ex; \
     microdnf clean all; \
     rm -rf /var/cache/yum
 
-# https://docs.couchdb.org/en/stable/install/unix.html
-# ENV GPG_COUCH_KEY \
-# # gpg: key D401AB61: public key "Bintray (by JFrog) <bintray@bintray.com> imported
-#        8756C4F765C9AC3CB6B85D62379CE192D401AB61
-# RUN set -xe; \
-#         export GNUPGHOME="$(mktemp -d)"; \
-#         echo "disable-ipv6" >> ${GNUPGHOME}/dirmngr.conf; \
-#         for server in $(shuf -e pgpkeys.mit.edu \
-#             ha.pool.sks-keyservers.net \
-#             hkp://p80.pool.sks-keyservers.net:80 \
-#             pgp.mit.edu) ; do \
-#                 gpg --batch --keyserver $server --recv-keys $GPG_COUCH_KEY && break || : ; \
-#         done; \
-#         gpg --batch --export $GPG_COUCH_KEY > /etc/apt/trusted.gpg.d/couchdb.gpg; \
-#         command -v gpgconf && gpgconf --kill all || :; \
-#         rm -rf "$GNUPGHOME"; \
-#         apt-key list
-
 # Install CouchDB
 RUN set -xe; \
     microdnf update --disableplugin=subscription-manager -y && rm -rf /var/cache/yum; \
-    microdnf install --enablerepo=bintray-apache-couchdb-rpm -y couchdb-3.1.1; \
+    microdnf install --enablerepo=couchdb -y couchdb-${COUCHDB_VERSION}; \
     microdnf clean all; \
     rm -rf /var/cache/yum; \
 # remove defaults that force writing logs to file

--- a/3.1.1-ubi-clouseau/bintray-apache-couchdb-rpm.repo
+++ b/3.1.1-ubi-clouseau/bintray-apache-couchdb-rpm.repo
@@ -1,6 +1,0 @@
-[bintray-apache-couchdb-rpm]
-name=bintray--apache-couchdb-rpm
-baseurl=http://apache.bintray.com/couchdb-rpm/el8/x86_64
-gpgcheck=0
-repo_gpgcheck=0
-enabled=1

--- a/3.1.1-ubi-clouseau/couchdb.repo
+++ b/3.1.1-ubi-clouseau/couchdb.repo
@@ -1,0 +1,7 @@
+[couchdb]
+name=couchdb
+baseurl=https://apache.jfrog.io/artifactory/couchdb-rpm/el$releasever/$basearch/
+gpgkey=https://couchdb.apache.org/repo/keys.asc https://couchdb.apache.org/repo/rpm-package-key.asc
+gpgcheck=1
+repo_gpgcheck=1
+enabled=1

--- a/3.1.1-ubi/Dockerfile
+++ b/3.1.1-ubi/Dockerfile
@@ -31,7 +31,7 @@ LABEL maintainer="CouchDB Developers dev@couchdb.apache.org" \
       io.openshift.min-cpu="1"
 
 COPY imeyer_runit.repo /etc/yum.repos.d/imeyer_runit.repo
-COPY bintray-apache-couchdb-rpm.repo /etc/yum.repos.d/bintray-apache-couchdb-rpm.repo
+COPY couchdb.repo /etc/yum.repos.d/couchdb.repo
 
 ENV COUCHDB_VERSION 3.1.1
 
@@ -55,28 +55,10 @@ RUN set -ex; \
     microdnf clean all; \
     rm -rf /var/cache/yum
 
-# https://docs.couchdb.org/en/stable/install/unix.html
-# ENV GPG_COUCH_KEY \
-# # gpg: key D401AB61: public key "Bintray (by JFrog) <bintray@bintray.com> imported
-#        8756C4F765C9AC3CB6B85D62379CE192D401AB61
-# RUN set -xe; \
-#         export GNUPGHOME="$(mktemp -d)"; \
-#         echo "disable-ipv6" >> ${GNUPGHOME}/dirmngr.conf; \
-#         for server in $(shuf -e pgpkeys.mit.edu \
-#             ha.pool.sks-keyservers.net \
-#             hkp://p80.pool.sks-keyservers.net:80 \
-#             pgp.mit.edu) ; do \
-#                 gpg --batch --keyserver $server --recv-keys $GPG_COUCH_KEY && break || : ; \
-#         done; \
-#         gpg --batch --export $GPG_COUCH_KEY > /etc/apt/trusted.gpg.d/couchdb.gpg; \
-#         command -v gpgconf && gpgconf --kill all || :; \
-#         rm -rf "$GNUPGHOME"; \
-#         apt-key list
-
 # Install CouchDB
 RUN set -xe; \
     microdnf update --disableplugin=subscription-manager -y && rm -rf /var/cache/yum; \
-    microdnf install --enablerepo=bintray-apache-couchdb-rpm -y couchdb-3.1.1; \
+    microdnf install --enablerepo=couchdb -y couchdb-${COUCHDB_VERSION}; \
     microdnf clean all; \
     rm -rf /var/cache/yum; \
 # remove defaults that force writing logs to file
@@ -85,8 +67,8 @@ RUN set -xe; \
     find /opt/couchdb \! \( -user couchdb -group 0 \) -exec chown -f couchdb:0 '{}' +; \
 # Setup directories and permissions for config. Technically these could be 555 and 444 respectively
 # but we keep them as 775 and 664 for consistency with the dockerfile_entrypoint.
-    find /opt/couchdb/etc -type d ! -perm 0755 -exec chmod -f 0755 '{}' +; \
-    find /opt/couchdb/etc -type f ! -perm 0644 -exec chmod -f 0644 '{}' +; \
+    find /opt/couchdb/etc -type d ! -perm 0775 -exec chmod -f 0775 '{}' +; \
+    find /opt/couchdb/etc -type f ! -perm 0664 -exec chmod -f 0664 '{}' +; \
 # Setup directories and permissions for data.
     chmod 777 /opt/couchdb/data
 

--- a/3.1.1-ubi/bintray-apache-couchdb-rpm.repo
+++ b/3.1.1-ubi/bintray-apache-couchdb-rpm.repo
@@ -1,6 +1,0 @@
-[bintray-apache-couchdb-rpm]
-name=bintray--apache-couchdb-rpm
-baseurl=http://apache.bintray.com/couchdb-rpm/el8/x86_64
-gpgcheck=0
-repo_gpgcheck=0
-enabled=1

--- a/3.1.1-ubi/couchdb.repo
+++ b/3.1.1-ubi/couchdb.repo
@@ -1,0 +1,7 @@
+[couchdb]
+name=couchdb
+baseurl=https://apache.jfrog.io/artifactory/couchdb-rpm/el$releasever/$basearch/
+gpgkey=https://couchdb.apache.org/repo/keys.asc https://couchdb.apache.org/repo/rpm-package-key.asc
+gpgcheck=1
+repo_gpgcheck=1
+enabled=1

--- a/3.1.1/Dockerfile
+++ b/3.1.1/Dockerfile
@@ -37,32 +37,33 @@ RUN set -eux; \
     gosu nobody true; \
     tini --version
 
-
 # http://docs.couchdb.org/en/latest/install/unix.html#installing-the-apache-couchdb-packages
 ENV GPG_COUCH_KEY \
-# gpg: key D401AB61: public key "Bintray (by JFrog) <bintray@bintray.com> imported
-    8756C4F765C9AC3CB6B85D62379CE192D401AB61
-RUN set -xe; \
+# gpg: rsa8192 205-01-19 The Apache Software Foundation (Package repository signing key) <root@apache.org>
+    390EF70BB1EA12B2773962950EE62FB37A00258D
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y curl; \
     export GNUPGHOME="$(mktemp -d)"; \
     echo "disable-ipv6" >> ${GNUPGHOME}/dirmngr.conf; \
-    for server in $(shuf -e pgpkeys.mit.edu \
-        ha.pool.sks-keyservers.net \
-        hkp://p80.pool.sks-keyservers.net:80 \
-        hkps://hkps.pool.sks-keyservers.net \
-        pgp.mit.edu) ; do \
-        gpg --batch --keyserver $server --recv-keys $GPG_COUCH_KEY && break || : ; \
-    done; \
-    gpg --batch --export $GPG_COUCH_KEY > /etc/apt/trusted.gpg.d/couchdb.gpg; \
+    curl https://couchdb.apache.org/repo/keys.asc | \
+        gpg --dearmor | \
+        tee /usr/share/keyrings/couchdb-archive-keyring.gpg >/dev/null 2>&1; \
+    gpg --show-keys /usr/share/keyrings/couchdb-archive-keyring.gpg | grep -q ${GPG_COUCH_KEY}; \
     command -v gpgconf && gpgconf --kill all || :; \
     rm -rf "$GNUPGHOME"; \
-    apt-key list
+    apt-key list; \
+    apt purge -y --autoremove curl; \
+    rm -rf /var/lib/apt/lists/*
 
 ENV COUCHDB_VERSION 3.1.1
 
-RUN echo "deb https://apache.bintray.com/couchdb-deb buster main" > /etc/apt/sources.list.d/couchdb.list
+RUN . /etc/os-release; \
+    echo "deb [signed-by=/usr/share/keyrings/couchdb-archive-keyring.gpg] https://apache.jfrog.io/artifactory/couchdb-deb/ ${VERSION_CODENAME} main" | \
+        tee /etc/apt/sources.list.d/couchdb.list >/dev/null
 
 # https://github.com/apache/couchdb-pkg/blob/master/debian/README.Debian
-RUN set -xe; \
+RUN set -eux; \
     apt-get update; \
     \
     echo "couchdb couchdb/mode select none" | debconf-set-selections; \

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -28,17 +28,6 @@ RUN apt-get update -y && apt-get install -y \
         libicu63 \
         libssl1.1 \
         openssl \
-    && echo "deb https://apache.bintray.com/couchdb-deb buster main" \
-        | tee /etc/apt/sources.list.d/couchdb.list \
-    && cat /etc/apt/sources.list.d/couchdb.list \
-    && for server in $(shuf -e pgpkeys.mit.edu \
-            ha.pool.sks-keyservers.net \
-            hkp://p80.pool.sks-keyservers.net:80 \
-            hkps://hkps.pool.sks-keyservers.net \
-            pgp.mit.edu) ; do \
-        gpg --batch --keyserver $server --recv-keys 8756C4F765C9AC3CB6B85D62379CE192D401AB61 && break || : ; \
-        done \
-    && gpg -a --export 8756C4F765C9AC3CB6B85D62379CE192D401AB61 > /etc/apt/trusted.gpg.d/couchdb.gpg.asc \
     && apt-get update -y && apt-get install -y --no-install-recommends libmozjs-60-0 \
     && rm -rf /var/lib/apt/lists/*
 
@@ -46,7 +35,7 @@ RUN apt-get update -y && apt-get install -y \
 # see https://github.com/apache/couchdb-docker/pull/28#discussion_r141112407
 ENV GOSU_VERSION 1.10
 ENV TINI_VERSION 0.16.1
-RUN set -ex; \
+RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends gosu tini; \
     rm -rf /var/lib/apt/lists/*; \
@@ -56,12 +45,14 @@ RUN set -ex; \
 # Dependencies only needed during build time. This layer will also be cached
 FROM runtime AS build_dependencies
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends \
+RUN set -eux; \
+    apt-get update -y && apt-get install -y --no-install-recommends \
     build-essential \
     libmozjs-60-dev \
     erlang-nox \
     erlang-reltool \
     erlang-dev \
+    erlang-dialyzer \
     git \
     libcurl4-openssl-dev \
     libicu-dev \
@@ -69,16 +60,25 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     libpython3-dev \
     python3-pip \
     python3-sphinx \
-    python3-setuptools
+    python3-setuptools \
+    wget
 
-RUN pip3 install --upgrade \
+RUN set -eux; \
+    pip3 install --upgrade \
     sphinx_rtd_theme \
     nose \
     requests \
     hypothesis
 
+RUN set -eux; \
+    wget https://www.foundationdb.org/downloads/6.3.9/ubuntu/installers/foundationdb-clients_6.3.9-1_amd64.deb; \
+    wget https://www.foundationdb.org/downloads/6.3.9/ubuntu/installers/foundationdb-server_6.3.9-1_amd64.deb; \
+    dpkg -i ./foundationdb*deb; \
+    pkill -f fdb || true; pkill -f foundation || true; \
+    rm -rf ./foundationdb*deb
+
 # Node is special
-RUN set -ex; \
+RUN set -eux; \
     curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -; \
     echo 'deb https://deb.nodesource.com/node_10.x buster main' > /etc/apt/sources.list.d/nodesource.list; \
     echo 'deb-src https://deb.nodesource.com/node_10.x buster main' >> /etc/apt/sources.list.d/nodesource.list; \


### PR DESCRIPTION
## Overview

Replaces old bintray references with new artifactory ones.
Replaces GPG key retrieval with direct pull from couchdb.apache.org.

## Testing recommendations

Build per usual process

## GitHub issue number

Closes #201 