### PR TITLE
fix(entrypoint): move secret from [couch_httpd_auth] to [chttpd_auth]

### DIFF
--- a/3.2.0-ubi-clouseau/resources/docker-entrypoint.sh
+++ b/3.2.0-ubi-clouseau/resources/docker-entrypoint.sh
@@ -101,8 +101,8 @@ if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
 
 	if [ "$COUCHDB_SECRET" ]; then
 		# Set secret only if not already present
-		if ! grep -Pzoqr "\[couch_httpd_auth\]\nsecret =" /opt/couchdb/etc/local.d/*.ini; then
-			printf "\n[couch_httpd_auth]\nsecret = %s\n" "$COUCHDB_SECRET" >> /opt/couchdb/etc/local.d/docker.ini
+		if ! grep -Pzoqr "\[chttpd_auth\]\nsecret =" /opt/couchdb/etc/local.d/*.ini; then
+			printf "\n[chttpd_auth]\nsecret = %s\n" "$COUCHDB_SECRET" >> /opt/couchdb/etc/local.d/docker.ini
 		fi
 	fi
 

--- a/3.2.0/docker-entrypoint.sh
+++ b/3.2.0/docker-entrypoint.sh
@@ -72,8 +72,8 @@ if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
 
 	if [ "$COUCHDB_SECRET" ]; then
 		# Set secret only if not already present
-		if ! grep -Pzoqr "\[couch_httpd_auth\]\nsecret =" /opt/couchdb/etc/local.d/*.ini /opt/couchdb/etc/local.ini; then
-			printf "\n[couch_httpd_auth]\nsecret = %s\n" "$COUCHDB_SECRET" >> /opt/couchdb/etc/local.d/docker.ini
+		if ! grep -Pzoqr "\[chttpd_auth\]\nsecret =" /opt/couchdb/etc/local.d/*.ini /opt/couchdb/etc/local.ini; then
+			printf "\n[chttpd_auth]\nsecret = %s\n" "$COUCHDB_SECRET" >> /opt/couchdb/etc/local.d/docker.ini
 		fi
 	fi
 

--- a/3.2.1/docker-entrypoint.sh
+++ b/3.2.1/docker-entrypoint.sh
@@ -72,8 +72,8 @@ if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
 
 	if [ "$COUCHDB_SECRET" ]; then
 		# Set secret only if not already present
-		if ! grep -Pzoqr "\[couch_httpd_auth\]\nsecret =" /opt/couchdb/etc/local.d/*.ini /opt/couchdb/etc/local.ini; then
-			printf "\n[couch_httpd_auth]\nsecret = %s\n" "$COUCHDB_SECRET" >> /opt/couchdb/etc/local.d/docker.ini
+		if ! grep -Pzoqr "\[chttpd_auth\]\nsecret =" /opt/couchdb/etc/local.d/*.ini /opt/couchdb/etc/local.ini; then
+			printf "\n[chttpd_auth]\nsecret = %s\n" "$COUCHDB_SECRET" >> /opt/couchdb/etc/local.d/docker.ini
 		fi
 	fi
 

--- a/dev/docker-entrypoint.sh
+++ b/dev/docker-entrypoint.sh
@@ -64,8 +64,8 @@ if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
 
 	if [ "$COUCHDB_SECRET" ]; then
 		# Set secret only if not already present
-		if ! grep -Pzoqr "\[couch_httpd_auth\]\nsecret =" /opt/couchdb/etc/local.d/*.ini /opt/couchdb/etc/local.ini; then
-			printf "\n[couch_httpd_auth]\nsecret = %s\n" "$COUCHDB_SECRET" >> /opt/couchdb/etc/local.d/docker.ini
+		if ! grep -Pzoqr "\[chttpd_auth\]\nsecret =" /opt/couchdb/etc/local.d/*.ini /opt/couchdb/etc/local.ini; then
+			printf "\n[chttpd_auth]\nsecret = %s\n" "$COUCHDB_SECRET" >> /opt/couchdb/etc/local.d/docker.ini
 		fi
 	fi
 


### PR DESCRIPTION
## Overview

With CouchDB 3.2+ the `secret` has moved from `[couch_httpd_auth]` to the `[chttpd_auth]` section. See the [documentation](https://docs.couchdb.org/en/stable/config/auth.html#chttpd_auth/secret).

The cluster setup fails with the reason `Cluster setup unable to sync admin passwords` when using the `couchdb:3.2.1` Docker image and environment variable `COUCHDB_SECRET=a-secret`.

This pull request makes the entrypoint script use the correct config section to configure the provided secret.

## Testing recommendations

A rebuild of the Docker image with the fixed docker-entrypoint.sh makes the cluster setup succeed.

## Checklist

- [x] Code is written and works correctly;
- [n/a] Changes are covered by tests;
- [n/a] Documentation reflects the changes;
