### PR TITLE
Listen for COUCHDB_ERLANG_COOKIE and write it down

### DIFF
--- a/3.2.1/docker-entrypoint.sh
+++ b/3.2.1/docker-entrypoint.sh
@@ -77,6 +77,21 @@ if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
 		fi
 	fi
 
+	if [ "$COUCHDB_ERLANG_COOKIE" ]; then
+		cookieFile='/opt/couchdb/.erlang.cookie'
+		if [ -e "$cookieFile" ]; then
+			if [ "$(cat "$cookieFile" 2>/dev/null)" != "$COUCHDB_ERLANG_COOKIE" ]; then
+				echo >&2
+				echo >&2 "warning: $cookieFile contents do not match COUCHDB_ERLANG_COOKIE"
+				echo >&2
+			fi
+		else
+			echo "$COUCHDB_ERLANG_COOKIE" > "$cookieFile"
+		fi
+		chown couchdb:couchdb "$cookieFile"
+		chmod 600 "$cookieFile"
+	fi
+
 	if [ "$(id -u)" = '0' ]; then
 		chown -f couchdb:couchdb /opt/couchdb/etc/local.d/docker.ini || true
 	fi

--- a/README.md
+++ b/README.md
@@ -52,7 +52,14 @@ If you intend to network this CouchDB instance with others in a cluster, you wil
 
 Start your multiple CouchDB instances, then follow the Setup Wizard in the [official CouchDB documentation](http://docs.couchdb.org/en/stable/setup/cluster.html) to complete the process.
 
-For a CouchDB cluster you need to provide the `NODENAME` setting as well as the erlang cookie. Settings to Erlang can be made with the environment variable `ERL_FLAGS`, e.g. `ERL_FLAGS=-setcookie "brumbrum"`.
+For a CouchDB cluster you need to provide the `NODENAME` setting as well as the
+Erlang distribution cookie. The current version of this image allows the Erlang
+cookie to be set directly using the `COUCHDB_ERLANG_COOKIE` environment
+variable. The contents of that environment variable will be written to
+`/opt/couchdb/.erlang.cookie` with the proper permissions. Previously one would
+need to provide the `-setcookie` flag in the environment variable `ERL_FLAGS`,
+e.g. `ERL_FLAGS=-setcookie "brumbrum"`.
+
 By default, this image exposes the `epmd` port `4369` and the Erlang cluster communication port `9100` (i.e. `inet_dist_listen_min` and `inet_dist_listen_max` are both 9100).
 Further information can be found [here](http://docs.couchdb.org/en/stable/cluster/setup.html).
 

--- a/dev/docker-entrypoint.sh
+++ b/dev/docker-entrypoint.sh
@@ -69,6 +69,21 @@ if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
 		fi
 	fi
 
+	if [ "$COUCHDB_ERLANG_COOKIE" ]; then
+		cookieFile='/opt/couchdb/.erlang.cookie'
+		if [ -e "$cookieFile" ]; then
+			if [ "$(cat "$cookieFile" 2>/dev/null)" != "$COUCHDB_ERLANG_COOKIE" ]; then
+				echo >&2
+				echo >&2 "warning: $cookieFile contents do not match COUCHDB_ERLANG_COOKIE"
+				echo >&2
+			fi
+		else
+			echo "$COUCHDB_ERLANG_COOKIE" > "$cookieFile"
+		fi
+		chown couchdb:couchdb "$cookieFile"
+		chmod 600 "$cookieFile"
+	fi
+
 	chown -f couchdb:couchdb /opt/couchdb/etc/local.d/docker.ini || true
 
 	# if we don't find an [admins] section followed by a non-comment, display a warning


### PR DESCRIPTION
## Overview

This just makes it simpler to install an Erlang distribution cookie. If the COUCHDB_ERLANG_COOKIE environment variable is set, the entry point script will take its contents and write them as ~/.erlang.cookie.

The `-setcookie` approach in ERL_FLAGS still works, and will take precedence over the COUCHDB_ERLANG_COOKIE.

## Testing recommendations

Build the image and then start a container like

```
docker run --env COUCHDB_ERLANG_COOKIE=foobaz --env COUCHDB_USER=admin --env COUCHDB_PASSWORD=foo --env NODENAME=localhost apache/couchdb:latest
```

Fire up a shell on the container and you should see `/opt/couchdb/.erlang.cookie` with contents 'foobaz'.

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [x] Documentation reflects the changes;
