### PR TITLE
Restore ppc64le support, update Debian+Erlang+SpiderMonkey

### DIFF
--- a/3.2.1/Dockerfile
+++ b/3.2.1/Dockerfile
@@ -10,7 +10,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 LABEL maintainer="CouchDB Developers dev@couchdb.apache.org"
 
@@ -54,7 +54,7 @@ RUN set -eux; \
     apt purge -y --autoremove curl; \
     rm -rf /var/lib/apt/lists/*
 
-ENV COUCHDB_VERSION 3.2.1
+ENV COUCHDB_VERSION 3.2.1-1
 
 RUN . /etc/os-release; \
     echo "deb [signed-by=/usr/share/keyrings/couchdb-archive-keyring.gpg] https://apache.jfrog.io/artifactory/couchdb-deb/ ${VERSION_CODENAME} main" | \
@@ -67,7 +67,7 @@ RUN set -eux; \
     echo "couchdb couchdb/mode select none" | debconf-set-selections; \
 # we DO want recommends this time
     DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-held-packages \
-            couchdb="$COUCHDB_VERSION"~buster \
+            couchdb="$COUCHDB_VERSION"~bullseye \
     ; \
 # Undo symlinks to /var/log and /var/lib
     rmdir /var/lib/couchdb /var/log/couchdb; \

--- a/build.sh
+++ b/build.sh
@@ -33,8 +33,8 @@ set -e
 
 PROMPT="Are you sure (y/n)? "
 QEMU="YES"
-PLATFORMS="amd64 arm64v8"
-BUILDX_PLATFORMS="linux/amd64,linux/arm64/v8"
+PLATFORMS="amd64 arm64v8 ppc64le"
+BUILDX_PLATFORMS="linux/amd64,linux/arm64/v8,linux/ppc64le"
 
 prompt() {
   if [ -z "${PROMPT}" ]
@@ -153,10 +153,14 @@ push() {
   fi
   docker manifest create apache/couchdb:$tag_as \
     apache/couchdb:amd64-$1 \
-    apache/couchdb:arm64v8-$1
+    apache/couchdb:arm64v8-$1 \
+    apache/couchdb:ppc64le-$1
 
   docker manifest annotate apache/couchdb:$tag_as \
     apache/couchdb:arm64v8-$1 --os linux --arch arm64 --variant v8
+
+  docker manifest annotate apache/couchdb:$tag_as \
+    apache/couchdb:ppc64le-$1 --os linux --arch ppc64le
 
   docker manifest push --purge apache/couchdb:$tag_as
 


### PR DESCRIPTION
## Overview

Several modernizations to our latest production image:

1. Re-add ppc64le support to the platform matrix, as we [do run this in CI](https://github.com/apache/couchdb/blob/e4b8a4624fc7ae09b4649aac9a8d68226208cd8b/build-aux/Jenkinsfile.full#L69-L74) once more.
2. Bump Debian 10 -> Debian 11
3. Bump Erlang 20 -> Erlang 23
4.  Bump SpiderMonkey 60 -> SpiderMonkey 78

#  Testing recommendations

- We have been running Debian 11 + Erlang 23 in Jenkins for PRs since apache/couchdb-ci#30
- We also started using Erlang 23 as the default for Full Platform Builds in apache/couchdb#3903
- Images constructed using this branch are already posted to https://hub.docker.com/r/apache/couchdb/tags

## GitHub issue number

Fixes #213

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
