### PR TITLE
Add 3.2.2 UBI / Clouseau reference container

### DIFF
--- a/3.2.2-ubi-clouseau/Dockerfile
+++ b/3.2.2-ubi-clouseau/Dockerfile
@@ -1,0 +1,137 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+ARG CLOUSEAU_VERSION=2.21.0
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal as builder
+
+ARG CLOUSEAU_VERSION
+ARG SLF4J_SIMPLE_BINDING_VERSION=1.7.36
+
+WORKDIR /usr/src
+
+# Fetch and extract clouseau
+RUN set -xe; \
+    microdnf update -y && rm -rf /var/cache/yum && \
+    microdnf install -y unzip wget maven && \
+    wget https://github.com/cloudant-labs/clouseau/releases/download/${CLOUSEAU_VERSION}/clouseau-${CLOUSEAU_VERSION}-dist.zip && \
+    unzip -j clouseau-${CLOUSEAU_VERSION}-dist.zip -d clouseau && \ 
+    microdnf clean all; \
+    rm -rf /var/cache/yum
+
+# Fetch and extract slf4j simplelogger binding (log to console)
+RUN mvn dependency:get -Dartifact=org.slf4j:slf4j-simple:${SLF4J_SIMPLE_BINDING_VERSION} && \
+    mvn dependency:copy -Dartifact=org.slf4j:slf4j-simple:${SLF4J_SIMPLE_BINDING_VERSION}:jar -DoutputDirectory=clouseau
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+ARG RELEASE
+ARG BUILD_DATE
+ARG CLOUSEAU_VERSION
+
+LABEL maintainer="CouchDB Developers dev@couchdb.apache.org" \
+      name="Apache CouchDB" \
+      version="3.2.2" \
+      summary="Apache CouchDB based on Red Hat UBI" \
+      description="Red Hat OpenShift-compatible container that runs Apache CouchDB" \
+      release=${RELEASE}  \
+      usage="https://github.com/apache/couchdb-docker" \
+      build-date=${BUILD_DATE} \
+      io.k8s.display-name="Apache CouchDB" \
+      io.k8s.description="Red Hat OpenShift-compatible container that runs Apache CouchDB" \
+      io.openshift.tags="database couchdb apache rhel8" \
+      io.openshift.expose-services="5984/http,4369/epmd,9100/erlang" \
+      io.openshift.min-memory="1Gi" \
+      io.openshift.min-cpu="1"
+
+COPY imeyer_runit.repo /etc/yum.repos.d/imeyer_runit.repo
+COPY couchdb.repo /etc/yum.repos.d/couchdb.repo
+
+ENV COUCHDB_VERSION=3.2.2 \
+    CLOUSEAU_VERSION=${CLOUSEAU_VERSION} \
+    JAVA_MAJOR_VERSION=8 \
+    JAVA_HOME=/usr/lib/jvm/jre-1.8.0 \
+    CLASSPATH=${APP_ROOT}/lib/*
+
+# Add CouchDB user account to make sure the IDs are assigned consistently
+# CouchDB user added to root group for OpenShift support
+RUN set -ex; \
+# be sure GPG and apt-transport-https are available and functional
+    microdnf update -y && rm -rf /var/cache/yum; \
+    microdnf install -y \
+            java-1.8.0-openjdk-headless \
+            ca-certificates \
+            gnupg \
+            findutils \
+            shadow-utils; \
+# Add CouchDB User and Group (group required by rpm)
+    useradd -u 5984 -d /opt/couchdb -g root couchdb; \
+    groupadd -g 5984 couchdb; \
+# Install runit
+    microdnf update --disableplugin=subscription-manager -y && rm -rf /var/cache/yum; \
+    microdnf install --enablerepo=imeyer_runit -y runit; \
+# Clean up
+    microdnf clean all; \
+    rm -rf /var/cache/yum
+
+# Install CouchDB
+RUN set -xe; \
+    microdnf update --disableplugin=subscription-manager -y && rm -rf /var/cache/yum; \
+    microdnf install --enablerepo=couchdb -y couchdb-${COUCHDB_VERSION}; \
+    microdnf clean all; \
+    rm -rf /var/cache/yum; \
+# remove defaults that force writing logs to file
+    rm /opt/couchdb/etc/default.d/10-filelog.ini; \
+# Check we own everything in /opt/couchdb. Matches the command in dockerfile_entrypoint.sh
+    find /opt/couchdb \! \( -user couchdb -group 0 \) -exec chown -f couchdb:0 '{}' +; \
+# Setup directories and permissions for config. Technically these could be 555 and 444 respectively
+# but we keep them as 775 and 664 for consistency with the dockerfile_entrypoint.
+    find /opt/couchdb/etc -type d ! -perm 0755 -exec chmod -f 0755 '{}' +; \
+    find /opt/couchdb/etc -type f ! -perm 0644 -exec chmod -f 0644 '{}' +; \
+# Setup directories and permissions for data.
+    chmod 777 /opt/couchdb/data
+
+# Copy Clouseau jar and set directory permissions
+COPY resources/clouseau/clouseau.ini /opt/couchdb-search/etc/
+COPY resources/clouseau/simplelogger.properties /opt/couchdb-search/lib/
+COPY --from=builder /usr/src/clouseau/*.jar /opt/couchdb-search/lib/
+
+RUN install -d -m 0755 -o couchdb -g 0 -p /opt/couchdb-search/etc /opt/couchdb-search/lib /opt/couchdb/data/search_indexes && \
+    find -L /opt/couchdb-search \! \( -user couchdb -group 0 \) -exec chown -f couchdb:0 '{}' +; \
+	find -L /opt/couchdb-search -type d ! -perm 0755 -exec chmod -f 0755 '{}' +; \
+    find -L /opt/couchdb-search -type f ! -perm 0644 -exec chmod -f 0644 '{}' +;
+
+# Add the License
+COPY licenses /licenses
+
+# Add configuration
+COPY --chown=couchdb:0 resources/10-docker-default.ini /opt/couchdb/etc/default.d/
+COPY --chown=couchdb:0 resources/vm.args /opt/couchdb/etc/
+COPY --chown=couchdb:0 resources/docker-entrypoint.sh /usr/local/bin
+COPY --chown=couchdb:0 resources/run /etc/service/couchdb/
+COPY --chown=couchdb:0 resources/run_clouseau /etc/service/couchdb-search/run
+
+# set permissions on runit scripts
+RUN chmod -R 777 /etc/service/couchdb; \
+    chmod -R 777 /etc/service/couchdb-search; \
+    chmod 777 /usr/local/bin/docker-entrypoint.sh; \
+# symlink to root folder
+    ln -s usr/local/bin/docker-entrypoint.sh /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+VOLUME /opt/couchdb/data
+
+# 5984: Main CouchDB endpoint
+# 4369: Erlang portmap daemon (epmd)
+# 9100: CouchDB cluster communication port
+EXPOSE 5984 4369 9100
+CMD ["/opt/couchdb/bin/couchdb"]

--- a/3.2.2-ubi-clouseau/couchdb.repo
+++ b/3.2.2-ubi-clouseau/couchdb.repo
@@ -1,0 +1,7 @@
+[couchdb]
+name=couchdb
+baseurl=https://apache.jfrog.io/artifactory/couchdb-rpm/el$releasever/$basearch/
+gpgkey=https://couchdb.apache.org/repo/keys.asc https://couchdb.apache.org/repo/rpm-package-key.asc
+gpgcheck=1
+repo_gpgcheck=1
+enabled=1

--- a/3.2.2-ubi-clouseau/imeyer_runit.repo
+++ b/3.2.2-ubi-clouseau/imeyer_runit.repo
@@ -1,0 +1,10 @@
+[imeyer_runit]
+name=imeyer_runit
+baseurl=https://packagecloud.io/imeyer/runit/el/7/x86_64
+repo_gpgcheck=1
+gpgcheck=0
+enabled=1
+gpgkey=https://packagecloud.io/imeyer/runit/gpgkey
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+metadata_expire=300

--- a/3.2.2-ubi-clouseau/licenses/LICENSE
+++ b/3.2.2-ubi-clouseau/licenses/LICENSE
@@ -1,0 +1,202 @@
+
+                                Apache License
+                          Version 2.0, January 2004
+                       http://www.apache.org/licenses/
+
+  TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+  1. Definitions.
+
+     "License" shall mean the terms and conditions for use, reproduction,
+     and distribution as defined by Sections 1 through 9 of this document.
+
+     "Licensor" shall mean the copyright owner or entity authorized by
+     the copyright owner that is granting the License.
+
+     "Legal Entity" shall mean the union of the acting entity and all
+     other entities that control, are controlled by, or are under common
+     control with that entity. For the purposes of this definition,
+     "control" means (i) the power, direct or indirect, to cause the
+     direction or management of such entity, whether by contract or
+     otherwise, or (ii) ownership of fifty percent (50%) or more of the
+     outstanding shares, or (iii) beneficial ownership of such entity.
+
+     "You" (or "Your") shall mean an individual or Legal Entity
+     exercising permissions granted by this License.
+
+     "Source" form shall mean the preferred form for making modifications,
+     including but not limited to software source code, documentation
+     source, and configuration files.
+
+     "Object" form shall mean any form resulting from mechanical
+     transformation or translation of a Source form, including but
+     not limited to compiled object code, generated documentation,
+     and conversions to other media types.
+
+     "Work" shall mean the work of authorship, whether in Source or
+     Object form, made available under the License, as indicated by a
+     copyright notice that is included in or attached to the work
+     (an example is provided in the Appendix below).
+
+     "Derivative Works" shall mean any work, whether in Source or Object
+     form, that is based on (or derived from) the Work and for which the
+     editorial revisions, annotations, elaborations, or other modifications
+     represent, as a whole, an original work of authorship. For the purposes
+     of this License, Derivative Works shall not include works that remain
+     separable from, or merely link (or bind by name) to the interfaces of,
+     the Work and Derivative Works thereof.
+
+     "Contribution" shall mean any work of authorship, including
+     the original version of the Work and any modifications or additions
+     to that Work or Derivative Works thereof, that is intentionally
+     submitted to Licensor for inclusion in the Work by the copyright owner
+     or by an individual or Legal Entity authorized to submit on behalf of
+     the copyright owner. For the purposes of this definition, "submitted"
+     means any form of electronic, verbal, or written communication sent
+     to the Licensor or its representatives, including but not limited to
+     communication on electronic mailing lists, source code control systems,
+     and issue tracking systems that are managed by, or on behalf of, the
+     Licensor for the purpose of discussing and improving the Work, but
+     excluding communication that is conspicuously marked or otherwise
+     designated in writing by the copyright owner as "Not a Contribution."
+
+     "Contributor" shall mean Licensor and any individual or Legal Entity
+     on behalf of whom a Contribution has been received by Licensor and
+     subsequently incorporated within the Work.
+
+  2. Grant of Copyright License. Subject to the terms and conditions of
+     this License, each Contributor hereby grants to You a perpetual,
+     worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+     copyright license to reproduce, prepare Derivative Works of,
+     publicly display, publicly perform, sublicense, and distribute the
+     Work and such Derivative Works in Source or Object form.
+
+  3. Grant of Patent License. Subject to the terms and conditions of
+     this License, each Contributor hereby grants to You a perpetual,
+     worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+     (except as stated in this section) patent license to make, have made,
+     use, offer to sell, sell, import, and otherwise transfer the Work,
+     where such license applies only to those patent claims licensable
+     by such Contributor that are necessarily infringed by their
+     Contribution(s) alone or by combination of their Contribution(s)
+     with the Work to which such Contribution(s) was submitted. If You
+     institute patent litigation against any entity (including a
+     cross-claim or counterclaim in a lawsuit) alleging that the Work
+     or a Contribution incorporated within the Work constitutes direct
+     or contributory patent infringement, then any patent licenses
+     granted to You under this License for that Work shall terminate
+     as of the date such litigation is filed.
+
+  4. Redistribution. You may reproduce and distribute copies of the
+     Work or Derivative Works thereof in any medium, with or without
+     modifications, and in Source or Object form, provided that You
+     meet the following conditions:
+
+     (a) You must give any other recipients of the Work or
+         Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices
+         stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works
+         that You distribute, all copyright, patent, trademark, and
+         attribution notices from the Source form of the Work,
+         excluding those notices that do not pertain to any part of
+         the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its
+         distribution, then any Derivative Works that You distribute must
+         include a readable copy of the attribution notices contained
+         within such NOTICE file, excluding those notices that do not
+         pertain to any part of the Derivative Works, in at least one
+         of the following places: within a NOTICE text file distributed
+         as part of the Derivative Works; within the Source form or
+         documentation, if provided along with the Derivative Works; or,
+         within a display generated by the Derivative Works, if and
+         wherever such third-party notices normally appear. The contents
+         of the NOTICE file are for informational purposes only and
+         do not modify the License. You may add Your own attribution
+         notices within Derivative Works that You distribute, alongside
+         or as an addendum to the NOTICE text from the Work, provided
+         that such additional attribution notices cannot be construed
+         as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and
+     may provide additional or different license terms and conditions
+     for use, reproduction, or distribution of Your modifications, or
+     for any such Derivative Works as a whole, provided Your use,
+     reproduction, and distribution of the Work otherwise complies with
+     the conditions stated in this License.
+
+  5. Submission of Contributions. Unless You explicitly state otherwise,
+     any Contribution intentionally submitted for inclusion in the Work
+     by You to the Licensor shall be under the terms and conditions of
+     this License, without any additional terms or conditions.
+     Notwithstanding the above, nothing herein shall supersede or modify
+     the terms of any separate license agreement you may have executed
+     with Licensor regarding such Contributions.
+
+  6. Trademarks. This License does not grant permission to use the trade
+     names, trademarks, service marks, or product names of the Licensor,
+     except as required for reasonable and customary use in describing the
+     origin of the Work and reproducing the content of the NOTICE file.
+
+  7. Disclaimer of Warranty. Unless required by applicable law or
+     agreed to in writing, Licensor provides the Work (and each
+     Contributor provides its Contributions) on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+     implied, including, without limitation, any warranties or conditions
+     of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+     PARTICULAR PURPOSE. You are solely responsible for determining the
+     appropriateness of using or redistributing the Work and assume any
+     risks associated with Your exercise of permissions under this License.
+
+  8. Limitation of Liability. In no event and under no legal theory,
+     whether in tort (including negligence), contract, or otherwise,
+     unless required by applicable law (such as deliberate and grossly
+     negligent acts) or agreed to in writing, shall any Contributor be
+     liable to You for damages, including any direct, indirect, special,
+     incidental, or consequential damages of any character arising as a
+     result of this License or out of the use or inability to use the
+     Work (including but not limited to damages for loss of goodwill,
+     work stoppage, computer failure or malfunction, or any and all
+     other commercial damages or losses), even if such Contributor
+     has been advised of the possibility of such damages.
+
+  9. Accepting Warranty or Additional Liability. While redistributing
+     the Work or Derivative Works thereof, You may choose to offer,
+     and charge a fee for, acceptance of support, warranty, indemnity,
+     or other liability obligations and/or rights consistent with this
+     License. However, in accepting such obligations, You may act only
+     on Your own behalf and on Your sole responsibility, not on behalf
+     of any other Contributor, and only if You agree to indemnify,
+     defend, and hold each Contributor harmless for any liability
+     incurred by, or claims asserted against, such Contributor by reason
+     of your accepting any such warranty or additional liability.
+
+  END OF TERMS AND CONDITIONS
+
+  APPENDIX: How to apply the Apache License to your work.
+
+     To apply the Apache License to your work, attach the following
+     boilerplate notice, with the fields enclosed by brackets "[]"
+     replaced with your own identifying information. (Don't include
+     the brackets!)  The text should be enclosed in the appropriate
+     comment syntax for the file format. We also recommend that a
+     file or class name and description of purpose be included on the
+     same "printed page" as the copyright notice for easier
+     identification within third-party archives.
+
+  Copyright [yyyy] [name of copyright owner]
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.

--- a/3.2.2-ubi-clouseau/resources/10-docker-default.ini
+++ b/3.2.2-ubi-clouseau/resources/10-docker-default.ini
@@ -1,0 +1,8 @@
+; CouchDB Configuration Settings
+
+; Custom settings should be made in this file. They will override settings
+; in default.ini, but unlike changes made to default.ini, this file won't be
+; overwritten on server upgrade.
+
+[chttpd]
+bind_address = any

--- a/3.2.2-ubi-clouseau/resources/clouseau/clouseau.ini
+++ b/3.2.2-ubi-clouseau/resources/clouseau/clouseau.ini
@@ -1,0 +1,6 @@
+[clouseau]
+name=clouseau@127.0.0.1
+
+dir=/opt/couchdb/data/search_indexes
+
+max_indexes_open=500

--- a/3.2.2-ubi-clouseau/resources/clouseau/clouseau.sh
+++ b/3.2.2-ubi-clouseau/resources/clouseau/clouseau.sh
@@ -1,0 +1,12 @@
+# chmod 0600 /opt/couchdb-search/etc/jmxremote.password
+
+exec -c "java -server \
+    -Xmx2G \
+    -Dsun.net.inetaddr.ttl=30 \
+    -Dsun.net.inetaddr.negative.ttl=30 \∂
+    -XX:OnOutOfMemoryError="kill -9 %p" \
+    -XX:+UseConcMarkSweepGC \
+    -XX:+CMSParallelRemarkEnabled \
+    -classpath '/opt/couchdb-search/lib/*' \
+    com.cloudant.clouseau.Main \
+    /opt/couchdb-search/etc/clouseau.ini"

--- a/3.2.2-ubi-clouseau/resources/clouseau/simplelogger.properties
+++ b/3.2.2-ubi-clouseau/resources/clouseau/simplelogger.properties
@@ -1,0 +1,34 @@
+# SLF4J's SimpleLogger configuration file
+# Simple implementation of Logger that sends all enabled log messages, for all defined loggers, to System.err.
+
+# Default logging detail level for all instances of SimpleLogger.
+# Must be one of ("trace", "debug", "info", "warn", or "error").
+# If not specified, defaults to "info".
+org.slf4j.simpleLogger.defaultLogLevel=info
+
+# Logging detail level for a SimpleLogger instance named "xxxxx".
+# Must be one of ("trace", "debug", "info", "warn", or "error").
+# If not specified, the default logging detail level is used.
+#org.slf4j.simpleLogger.log.xxxxx=
+
+# Set to true if you want the current date and time to be included in output messages.
+# Default is false, and will output the number of milliseconds elapsed since startup.
+org.slf4j.simpleLogger.showDateTime=true
+
+# The date and time format to be used in the output messages.
+# The pattern describing the date and time format is the same that is used in java.text.SimpleDateFormat.
+# If the format is not specified or is invalid, the default format is used.
+# The default format is yyyy-MM-dd HH:mm:ss:SSS Z.
+#org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS Z
+
+# Set to true if you want to output the current thread name.
+# Defaults to true.
+#org.slf4j.simpleLogger.showThreadName=true
+
+# Set to true if you want the Logger instance name to be included in output messages.
+# Defaults to true.
+#org.slf4j.simpleLogger.showLogName=true
+
+# Set to true if you want the last component of the name to be included in output messages.
+# Defaults to false.
+#org.slf4j.simpleLogger.showShortLogName=false

--- a/3.2.2-ubi-clouseau/resources/docker-entrypoint.sh
+++ b/3.2.2-ubi-clouseau/resources/docker-entrypoint.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+set -e
+
+# first arg is `-something` or `+something`
+if [ "${1#-}" != "$1" ] || [ "${1#+}" != "$1" ]; then
+	set -- /opt/couchdb/bin/couchdb "$@"
+fi
+
+# first arg is the bare word `couchdb`
+if [ "$1" = 'couchdb' ]; then
+	shift
+	set -- /opt/couchdb/bin/couchdb "$@"
+fi
+
+if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
+	# this is where runtime configuration changes will be written.
+	# we need to explicitly touch it here in case /opt/couchdb/etc has
+	# been mounted as an external volume, in which case it won't exist.
+	# If running as the couchdb user (i.e. container starts as root),
+	# write permissions will be granted below.
+	touch /opt/couchdb/etc/local.d/docker.ini
+
+	# if user is root, assume running under the couchdb user (default)
+	# and ensure it is able to access files and directories that may be mounted externally
+	if [ "$(id -u)" = '0' ]; then
+		# Check that we own everything in /opt/couchdb and fix if necessary. We also
+		# add the `-f` flag in all the following invocations because there may be
+		# cases where some of these ownership and permissions issues are non-fatal
+		# (e.g. a config file owned by root with o+r is actually fine), and we don't
+		# to be too aggressive about crashing here ...
+		find /opt/couchdb \! \( -user couchdb -group 0 \) -exec chown -f couchdb:0 '{}' +
+
+		# Ensure that data files have the correct permissions. We were previously
+		# preventing any access to these files outside of couchdb:couchdb, but it
+		# turns out that CouchDB itself does not set such restrictive permissions
+		# when it creates the files. The approach taken here ensures that the
+		# contents of the datadir have the same permissions as they had when they
+		# were initially created. This should minimize any startup delay.
+		find /opt/couchdb/data -type d ! -perm 0755 -exec chmod -f 0755 '{}' +
+		find /opt/couchdb/data -type f ! -perm 0644 -exec chmod -f 0644 '{}' +
+
+		# Do the same thing for configuration files and directories. Technically
+		# CouchDB only needs read access to the configuration files as all online
+		# changes will be applied to the "docker.ini" file below, but we set 644
+		# for the sake of consistency.
+		find /opt/couchdb/etc -type d ! -perm 0755 -exec chmod -f 0755 '{}' +
+		find /opt/couchdb/etc -type f ! -perm 0644 -exec chmod -f 0644 '{}' +
+
+		# also for clouseau
+		find -L /opt/couchdb-search \! \( -user couchdb -group 0 \) -exec chown -f couchdb:0 '{}' +
+		find -L /opt/couchdb-search -type d ! -perm 0755 -exec chmod -f 0755 '{}' +
+    	find -L /opt/couchdb-search -type f ! -perm 0644 -exec chmod -f 0644 '{}' +
+	fi
+
+	# if erlang cookie already set, set in clouseau.ini
+	kCOOKIE_REGEX='setcookie ([^ ]+)'
+	cookie=''
+	cookieFile='/opt/couchdb/.erlang.cookie'
+	if [ -e "$cookieFile" ]; then
+		cookieFileContents="$(cat "$cookieFile" 2>/dev/null)"
+	fi
+
+	# if ERL_FLAGS specifies cookie, use that
+	if [[ $ERL_FLAGS =~ $kCOOKIE_REGEX ]]; then
+		cookie="${BASH_REMATCH[1]}"
+	# else choose first from
+	# * COUCHDB_ERLANG_COOKIE env
+	# * .erlang.cookie file
+	# * UUID
+	# and pass it via ERL_FLAGS
+	else
+		if [ "$COUCHDB_ERLANG_COOKIE" ]; then
+			if [ -e "$cookieFileContents" ]; then
+				if [ "$cookieFileContents" != "$COUCHDB_ERLANG_COOKIE" ]; then
+					echo >&2
+					echo >&2 "warning: $cookieFile contents do not match COUCHDB_ERLANG_COOKIE"
+					echo >&2
+				fi
+			fi
+			cookie=$COUCHDB_ERLANG_COOKIE
+		# else look for .erlang.cookie file
+		elif [ -e "$cookieFileContents" ]; then
+			cookie=$cookieFileContents
+		# else use UUID
+		else 
+			cookie=$(cat /proc/sys/kernel/random/uuid)
+		fi
+
+		# set cookie via ERL_FLAGS
+		ERL_FLAGS="$ERL_FLAGS -setcookie $cookie"
+	fi 
+
+	if ! grep "cookie" /opt/couchdb-search/etc/clouseau.ini; then
+		echo "cookie=$cookie" >> /opt/couchdb-search/etc/clouseau.ini
+	fi
+
+	if [ ! -z "$NODENAME" ] && ! grep "couchdb@" /opt/couchdb/etc/vm.args; then
+		echo "-name couchdb@$NODENAME" >> /opt/couchdb/etc/vm.args
+	fi
+
+	# a node name is required for clouseau/distributed erlang.
+	# set if not specified via ERL_FLAGS or vm.args
+	kNAME_REGEX='\-name ([^ ]+)'
+	if ! [[ $ERL_FLAGS =~ $kNAME_REGEX ]]; then
+		echo "No -name found in ERL_FLAGS."
+		nodename=${NODENAME:=127.0.0.1}
+		if ! grep -e '-name' /opt/couchdb/etc/vm.args; then
+			echo "No -name found in vm.args. Using couchdb@$nodename"
+			echo "-name couchdb@$nodename" >> /opt/couchdb/etc/vm.args
+		fi
+	fi
+
+	if [ "$COUCHDB_USER" ] && [ "$COUCHDB_PASSWORD" ]; then
+		# Create admin only if not already present
+		if ! grep -Pzoqr "\[admins\]\n$COUCHDB_USER =" /opt/couchdb/etc/local.d/*.ini; then
+			printf "\n[admins]\n%s = %s\n" "$COUCHDB_USER" "$COUCHDB_PASSWORD" >> /opt/couchdb/etc/local.d/docker.ini
+		fi
+	fi
+
+	if [ "$COUCHDB_SECRET" ]; then
+		# Set secret only if not already present
+		if ! grep -Pzoqr "\[chttpd_auth\]\nsecret =" /opt/couchdb/etc/local.d/*.ini; then
+			printf "\n[chttpd_auth]\nsecret = %s\n" "$COUCHDB_SECRET" >> /opt/couchdb/etc/local.d/docker.ini
+		fi
+	fi
+
+	if [ "$(id -u)" = '0' ]; then
+		chown -f couchdb:0 /opt/couchdb/etc/local.d/docker.ini || true
+	fi
+
+	# if we don't find an [admins] section followed by a non-comment, display a warning
+    if ! grep -Pzoqr '\[admins\]\n[^;]\w+' /opt/couchdb/etc/default.d/*.ini /opt/couchdb/etc/local.d/*.ini; then
+		# The - option suppresses leading tabs but *not* spaces. :)
+		cat >&2 <<-'EOWARN'
+*************************************************************
+ERROR: CouchDB 3.0+ will no longer run in "Admin Party"
+       mode. You *MUST* specify an admin user and
+       password, either via your own .ini file mapped
+       into the container at /opt/couchdb/etc/local.ini
+       or inside /opt/couchdb/etc/local.d, or with
+       "-e COUCHDB_USER=admin -e COUCHDB_PASSWORD=password"
+       to set it via "docker run".
+*************************************************************
+EOWARN
+		exit 1
+	fi
+
+	if [ "$(id -u)" = '0' ]; then
+		# Run as CouchDB user
+		cat > /etc/service/couchdb/run <<-EOF
+			#!/bin/sh
+			export HOME=/opt/couchdb
+			exec 2>&1
+			exec chpst -u couchdb env ERL_FLAGS="$ERL_FLAGS" $@
+		EOF
+
+		cat > /etc/service/couchdb-search/run <<-EOF
+			#!/bin/sh
+			export HOME=/opt/couchdb-search
+			exec 2>&1
+			exec chpst -u couchdb java -server \
+				-Xmx2G \
+				-Dsun.net.inetaddr.ttl=30 \
+				-Dsun.net.inetaddr.negative.ttl=30 \
+				-XX:OnOutOfMemoryError="kill -9 %p" \
+				-XX:+UseConcMarkSweepGC \
+				-XX:+CMSParallelRemarkEnabled \
+				-classpath '/opt/couchdb-search/lib/*' \
+				com.cloudant.clouseau.Main \
+				/opt/couchdb-search/etc/clouseau.ini
+		EOF
+	else
+		# Write out runit scripts to start as the ambient uid
+		cat > /etc/service/couchdb/run <<-EOF
+			#!/bin/sh
+			export HOME=/opt/couchdb
+			exec 2>&1
+			exec chpst env ERL_FLAGS="$ERL_FLAGS" $@
+		EOF
+
+		cat > /etc/service/couchdb-search/run <<-EOF
+			#!/bin/sh
+			export HOME=/opt/couchdb-search
+			exec 2>&1
+			exec chpst java -server \
+				-Xmx2G \
+				-Dsun.net.inetaddr.ttl=30 \
+				-Dsun.net.inetaddr.negative.ttl=30 \
+				-XX:OnOutOfMemoryError="kill -9 %p" \
+				-XX:+UseConcMarkSweepGC \
+				-XX:+CMSParallelRemarkEnabled \
+				-classpath '/opt/couchdb-search/lib/*' \
+				com.cloudant.clouseau.Main \
+				/opt/couchdb-search/etc/clouseau.ini
+		EOF
+	fi
+
+	exec /sbin/runsvdir-start
+fi
+
+exec "$@"

--- a/3.2.2-ubi-clouseau/resources/pre_stop
+++ b/3.2.2-ubi-clouseau/resources/pre_stop
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+    terminationPeriod=300
+else
+    terminationPeriod=$1
+fi
+
+timeToSleep=5
+numIterations=$(awk -v var1=$terminationPeriod -v var2=$timeToSleep 'BEGIN { print  ( var1 / var2 ) }')
+
+# Mark each runsv service as down, which will send each process a TERM
+for file in /conf/service/*/supervise/control; do
+    echo "d" > $file;
+done
+
+# Allow the processes time to terminate gracefully
+i="0"
+while [ $i -lt $numIterations ]; do
+    numServices=$(find /conf/service/* -maxdepth 0 -type d | wc -l)
+    numDownServices=$(grep -r "^down$" /conf/service/*/supervise/stat | wc -l)
+    if [ $numServices -ne $numDownServices ]; then
+        sleep $timeToSleep
+        i=$[$i+1]
+    else
+        exit 0
+    fi
+done
+
+exit 1

--- a/3.2.2-ubi-clouseau/resources/run
+++ b/3.2.2-ubi-clouseau/resources/run
@@ -1,0 +1,1 @@
+# populated in dockerfile entrypoint so that ERL_FLAGS are propagated

--- a/3.2.2-ubi-clouseau/resources/run_clouseau
+++ b/3.2.2-ubi-clouseau/resources/run_clouseau
@@ -1,0 +1,1 @@
+# populated in dockerfile entrypoint

--- a/3.2.2-ubi-clouseau/resources/vm.args
+++ b/3.2.2-ubi-clouseau/resources/vm.args
@@ -1,0 +1,28 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# Ensure that the Erlang VM listens on a known port
+-kernel inet_dist_listen_min 9100
+-kernel inet_dist_listen_max 9100
+
+# Tell kernel and SASL not to log anything
+-kernel error_logger silent
+-sasl sasl_error_logger false
+
+# Use kernel poll functionality if supported by emulator
++K true
+
+# Start a pool of asynchronous IO threads
++A 16
+
+# Comment this line out to enable the interactive Erlang shell on startup
++Bd -noinput


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Provide an example container that includes the current CouchDB
and Clouseau releases.

How:

- Clone the 3.2.0-ubi-clouseau directory to `3.2.2-ubi-clouseau`
- In `3.2.2-ubi-clouseau`:
  - Update CouchDB to 3.2.2
  - Update Clouseau to 2.21.0
  - Import and configure the SLF4J Simple logger. Clouseau 2.20.0
    removed Log4J in favour of SLF4J. For most container applications,
    logging to Console only should suffice. If alternative SLF4J
    backends are required they can be imported / configured
    in a similar fashion.
  - Add support for the `COUCHDB_ERLANG_COOKIE` environment variable
    in the Dockerfile entrypoint. This is not precisely the same as in
    the images without Clouseau because the `-ubi-clouseau` images
    already supported passing in a cookie via `ERL_FLAGS` and extracting
    it to configure `clouseau` (which needs the cookie to connect
    to CouchDB). In this Dockerfile, we always pass the cookie via
    `ERL_FLAGS` and will extract it from `COUCHDB_ERLANG_COOKIE` if
    passed.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

```
cd 3.2.2-ubi-clouseau
docker build . -t couchdb:3.2.2-ubi-clouseau
```

To run the container:
```
docker run -it -e COUCHDB_USER=admin -e COUCHDB_PASSWORD=password -e COUCHDB_ERLANG_COOKIE=notamonster -p 5984:5984 couchdb:3.2.2-ubi-clouseau
```

I verified that the container starts, I can create / query search
indexes etc. I tested passing in `COUCHDB_ERLANG_COOKIE` but have
not tested permutations beyond that.

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-docker/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
