### PR TITLE
fix: set $HOME when stepping down from root

### DIFF
--- a/3.2.2/docker-entrypoint.sh
+++ b/3.2.2/docker-entrypoint.sh
@@ -114,6 +114,7 @@ EOWARN
 	fi
 
 	if [ "$(id -u)" = '0' ]; then
+		export HOME=$(echo ~couchdb)
 		exec setpriv --reuid=couchdb --regid=couchdb --clear-groups "$@"
 	fi
 fi

--- a/3.3.1/docker-entrypoint.sh
+++ b/3.3.1/docker-entrypoint.sh
@@ -114,6 +114,7 @@ EOWARN
 	fi
 
 	if [ "$(id -u)" = '0' ]; then
+		export HOME=$(echo ~couchdb)
 		exec setpriv --reuid=couchdb --regid=couchdb --clear-groups "$@"
 	fi
 fi

--- a/dev/docker-entrypoint.sh
+++ b/dev/docker-entrypoint.sh
@@ -103,7 +103,7 @@ EOWARN
 		exit 1
 	fi
 
-
+	export HOME=$(echo ~couchdb)
 	exec setpriv --reuid=couchdb --regid=couchdb --clear-groups "$@"
 fi
 


### PR DESCRIPTION
## Overview

Why:

In https://github.com/apache/couchdb-docker/pull/234 we moved from using `gosu` to `setpriv` to step down from the root user to the couchdb user.

There is a behavioural difference between and `gosu` and `setpriv` in that `gosu` will [set the $HOME environment variable](https://github.com/tianon/gosu/blob/master/setup-user.go#L45) to that of the target user.

Without this behaviour, `couchdb` includes the root user home directory (`/root`) in various search paths and crashes because it doesn't have read permissions.

How:

Explicitly set `$HOME` to the `couchdb` user home directory before we execute as the `couchdb` user, replicating the `gosu` behaviour.


## Testing recommendations

The easiest reproducer is:

```
$ docker run -it -e COUCHDB_USER=admin -e COUCHDB_PASSWORD=password -eNODENAME=foo couchdb:3.2.2

{"Kernel pid terminated",application_controller,"{application_start_failure,kernel,{{shutdown,{failed_to_start_child,net_sup,{shutdown,{failed_to_start_child,auth,{{error,\"Error when reading /root/.erlang.cookie: eacces\"},[{auth,init_cookie,0,[{file,\"auth.erl\"},{line,290}]},{auth,init,1,[{file,\"auth.erl\"},{line,144}]},{gen_server,init_it,2,[{file,\"gen_server.erl\"},{line,417}]},{gen_server,init_it,6,[{file,\"gen_server.erl\"},{line,385}]},{proc_lib,init_p_do_apply,3,[{file,\"proc_lib.erl\"},{line,226}]}]}}}}},{kernel,start,[normal,[]]}}}"}
Kernel pid terminated (application_controller) ({application_start_failure,kernel,{{shutdown,{failed_to_start_child,net_sup,{shutdown,{failed_to_start_child,auth,{{error,"Error when reading /root/.erl

Crash dump is being written to: erl_crash.dump...done
```

## GitHub issue number

https://github.com/apache/couchdb-docker/issues/236

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
