### PR TITLE
Chore: reduce attack surface for Docker image

### DIFF
--- a/3.3.1/Dockerfile
+++ b/3.3.1/Dockerfile
@@ -42,7 +42,7 @@ ENV GPG_COUCH_KEY \
     390EF70BB1EA12B2773962950EE62FB37A00258D
 RUN set -eux; \
     apt-get update; \
-    apt-get install -y curl; \
+    apt-get install -y --no-install-recommends curl; \
     export GNUPGHOME="$(mktemp -d)"; \
     curl -fL -o keys.asc https://couchdb.apache.org/repo/keys.asc; \
     gpg --batch --import keys.asc; \
@@ -65,7 +65,7 @@ RUN set -eux; \
     \
     echo "couchdb couchdb/mode select none" | debconf-set-selections; \
 # we DO want recommends this time
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-held-packages \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --allow-downgrades --allow-remove-essential --allow-change-held-packages \
             couchdb="$COUCHDB_VERSION"~bullseye \
     ; \
 # Undo symlinks to /var/log and /var/lib


### PR DESCRIPTION
Hi,

This pull request includes a small improvement for the Dockerfile, which should help improve the security of container and reduce the risk of potential attacks.

In detail:
- I added `--no-install-recommends` to remove unnecessary `apt` packages, that were not needed for the container's functionality.

As quoted from [CIS Docker Benchmark v1.5.0](https://www.cisecurity.org/benchmark/docker):
>**4.3 Ensure that unnecessary packages are not installed in the container**
>**Description:**
>Containers should have as small a footprint as possible, and should not contain unnecessary software packages which could increase their attack surface.
>**Rationale:**
>Unnecessary software should not be installed into containers, as doing so increases their attack surface. Only packages strictly necessary for the correct operation of the application being deployed should be installed.


I built the Dockerfile before and after the improvement, there are 3 unnecessary packages that are removed: `libgpm2 psmisc publicsuffix`.

I hope that you find them useful. Please let me know if you have any concerns.

Thank you.