### PR TITLE
Add s390x support to CouchDB docker image

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -33,8 +33,8 @@ set -e
 
 PROMPT="Are you sure (y/n)? "
 QEMU="YES"
-PLATFORMS="amd64 arm64v8 ppc64le"
-BUILDX_PLATFORMS="linux/amd64,linux/arm64/v8,linux/ppc64le"
+PLATFORMS="amd64 arm64v8 ppc64le s390x"
+BUILDX_PLATFORMS="linux/amd64,linux/arm64/v8,linux/ppc64le,linux/s390x"
 
 prompt() {
   if [ -z "${PROMPT}" ]
@@ -75,6 +75,7 @@ update_qemu() {
   echo "Proving all emulators work..."
   docker run --rm arm32v7/alpine uname -a
   docker run --rm arm64v8/alpine uname -a
+  docker run --rm s390x/alpine uname -a
   docker run --rm tonistiigi/debian:riscv uname -a
 }
 
@@ -152,13 +153,17 @@ push() {
   docker manifest create apache/couchdb:$tag_as \
     apache/couchdb:amd64-$1 \
     apache/couchdb:arm64v8-$1 \
-    apache/couchdb:ppc64le-$1
+    apache/couchdb:ppc64le-$1 \
+    apache/couchdb:s390x-$1
 
   docker manifest annotate apache/couchdb:$tag_as \
     apache/couchdb:arm64v8-$1 --os linux --arch arm64 --variant v8
 
   docker manifest annotate apache/couchdb:$tag_as \
     apache/couchdb:ppc64le-$1 --os linux --arch ppc64le
+  
+  docker manifest annotate apache/couchdb:$tag_as \
+    apache/couchdb:s390x-$1 --os linux --arch s390x
 
   docker manifest push --purge apache/couchdb:$tag_as
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
Since the s390x .deb binary on debian:bullseye is released from v3.3.2 afterwards and all pre-requisites mentioned in https://github.com/apache/couchdb-docker/issues/67#issue-293689385 are available now, this PR aims to add s390x support to CouchDB docker image.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

https://github.com/apache/couchdb-docker#how-to-use-this-image
https://docs.couchdb.org/en/stable/intro/tour.html

I've built the multi-arch docker image on an Intel VM after applying the code change in this PR and verified the generated s390x image on a s390x VM. It worked fine.

## GitHub issue number
https://github.com/apache/couchdb-docker/issues/67
<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-docker/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
