### PR TITLE
Extend branch protection of main branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -14,5 +14,13 @@ github:
     - network-server
     - javascript
   protected_branches:
-    main
+    main:
+      required_status_checks:
+        strict: true
+      required_pull_request_reviews:
+        # Set to true if you want to automatically dismiss approving reviews when someone pushes a new commit.
+        dismiss_stale_reviews: false
+        # Specifies the number of reviewers required to approve pull requests.
+        # Use a number between 1 and 6 or 0 to not require reviewers.
+        required_approving_review_count: 1
 


### PR DESCRIPTION
Adding strict status check and at least one approval is needed.