### PR TITLE
Update debian

### DIFF
--- a/3.3.2/Dockerfile
+++ b/3.3.2/Dockerfile
@@ -10,7 +10,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 LABEL maintainer="CouchDB Developers dev@couchdb.apache.org"
 
@@ -66,7 +66,7 @@ RUN set -eux; \
     echo "couchdb couchdb/mode select none" | debconf-set-selections; \
 # we DO want recommends this time
     DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-held-packages \
-            couchdb="$COUCHDB_VERSION"~bullseye \
+            couchdb="$COUCHDB_VERSION"~bookworm \
     ; \
 # Undo symlinks to /var/log and /var/lib
     rmdir /var/lib/couchdb /var/log/couchdb; \

--- a/3.3.3/Dockerfile
+++ b/3.3.3/Dockerfile
@@ -10,7 +10,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 LABEL maintainer="CouchDB Developers dev@couchdb.apache.org"
 
@@ -66,7 +66,7 @@ RUN set -eux; \
     echo "couchdb couchdb/mode select none" | debconf-set-selections; \
 # we DO want recommends this time
     DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-held-packages \
-            couchdb="$COUCHDB_VERSION"~bullseye \
+            couchdb="$COUCHDB_VERSION"~bookworm \
     ; \
 # Undo symlinks to /var/log and /var/lib
     rmdir /var/lib/couchdb /var/log/couchdb; \


### PR DESCRIPTION
## Overview

Update Debian from Bullseye (oldstable) to Bookworm (stable)

## Testing recommendations

CouchDB itself is known to run on Bookworm--that testing was done by the core project.

I would suggest just basic testing--does it build, does it run.

## GitHub issue number

Fixes #258 

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
