### PR TITLE
docs(nouveau): add additional nouveau ini config

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,17 @@ In addition, a few environment variables are provided to set very common paramet
 * `NODENAME` will set the name of the CouchDB node inside the container to `couchdb@${NODENAME}`, in the file `/opt/couchdb/etc/vm.args`. This is used for clustering purposes and can be ignored for single-node setups.
 * Erlang Environment Variables like `ERL_FLAGS` will be used by Erlang itself. For a complete list have a look [here](http://erlang.org/doc/man/erl.html#environment-variables)
 
+## Configure CouchDB Nouveau
+
+Using the `couchdb:3.4-nouveau` image with `couchdb:3.4` container, there are additional configurations required to set the communication between the containers. CouchDB by default communicates with Nouveau at `http://localhost:5987`, which would now be running in a different container. To enable the communication, the CouchDB container should know the location of Nouveau location and enable the configuration. This can be done by puting following configuration file at `/opt/couchdb/etc/local.d/nouveau.ini` in the CouchDB container.
+
+```ini
+[nouveau]
+enable = true
+url = http://couchdb-nouveau:5987
+```
+
+**Note:** Replace the location in the URL.
 
 # Caveats
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Add additional configuration to setup different container running `couchdb:3.4.1` and `couchdb:3.4.1-nouveau` images.

## Testing recommendations

Please check if the information added is correct.

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [x] Documentation reflects the changes;
