### PR TITLE
docs(nouveau): add compose example with nouveau

### DIFF
--- a/nouveau-compose/README.md
+++ b/nouveau-compose/README.md
@@ -1,0 +1,55 @@
+standard `docker-compose.yml`.
+
+```shell
+mkdir -p ./config/couchdb
+```
+
+**./config/couchdb/nouveau.ini**
+```ini
+[nouveau]
+enable = true
+url = http://couchdb-nouveau:5987
+```
+
+**docker-compose.yml**
+*This yaml expose 5984 to the host network, if you already using the 5984 change it on the yaml
+```yaml
+services:
+  couchdb:
+    image: couchdb:3.4.1
+    restart: unless-stopped
+    ports:
+      - 5984:5984
+    environment:
+      - ERL_FLAGS=-setcookie monster
+      - COUCHDB_CREATE_DATABASE=yes
+    depends_on:
+      - couchdb-nouveau
+    volumes:
+      - couchdb:/opt/couchdb/data
+      - ./config/couchdb/nouveau.ini:/opt/couchdb/etc/local.d/nouveau.ini
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail -s http://couchdb:5984/_up"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+
+  couchdb-nouveau:
+    image: couchdb:3.4.1-nouveau
+#    ports:
+#      - "5987:5987"
+#      - "5988:5988"
+
+networks:
+  default:
+    name: couchdb-net
+```
+
+```shell
+docker-compose up
+```
+
+Check it http://127.0.0.1:5984
+
+The _trick_ is the `./config/couchdb/nouveau.ini` defines the `couchdb-nouveau` to be running on docker network service named `couchdb-nouveau`. So the port (5987) mapped to the nouveau container.
+


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Add example `docker-compose.yml` file to use `couchdb` and `couchdb-nouveau`.

## Testing recommendations

Starting the services should have couchdb and nouveau configured correctly.

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [x] Documentation reflects the changes;
