### PR TITLE
feat(dev/Dockerfile): Add ability to load secrets from files

### DIFF
--- a/dev/docker-entrypoint.sh
+++ b/dev/docker-entrypoint.sh
@@ -24,6 +24,41 @@ if [ "$1" = 'couchdb' ]; then
 	set -- /opt/couchdb/bin/couchdb "$@"
 fi
 
+# This function will populate the admin user in the docker.ini file using the first argument, the second argument is the password.
+function set_admin_credentials {
+  adminUser="$1"
+  adminPassword="$2"
+  # Create admin only if not already present
+  if ! grep -Pzoqr "\[admins\]\n$adminUser =" /opt/couchdb/etc/local.d/*.ini /opt/couchdb/etc/local.ini; then
+    printf "\n[admins]\n%s = %s\n" "$adminUser" "$adminPassword" >> /opt/couchdb/etc/local.d/docker.ini
+  fi
+}
+
+# This function populates the chttpd_auth secret in the docker.ini file using the first argument.
+function set_http_secret {
+  chttpSecret="$1"
+  if ! grep -Pzoqr "\[chttpd_auth\]\nsecret =" /opt/couchdb/etc/local.d/*.ini /opt/couchdb/etc/local.ini; then
+    printf "\n[chttpd_auth]\nsecret = %s\n" "$chttpSecret" >> /opt/couchdb/etc/local.d/docker.ini
+  fi
+}
+
+# This function populates the erlang cookie in the .erlang.cookie file using the first argument.
+function set_erlang_cookie {
+  erlangCookie="$1"
+  cookieFile='/opt/couchdb/.erlang.cookie'
+		if [ -e "$cookieFile" ]; then
+			if [ "$(cat "$cookieFile" 2>/dev/null)" != "$erlangCookie" ]; then
+				echo >&2
+				echo >&2 "warning: $cookieFile contents do not match COUCHDB_ERLANG_COOKIE"
+				echo >&2
+			fi
+		else
+			echo "$erlangCookie" > "$cookieFile"
+		fi
+		chown couchdb:couchdb "$cookieFile"
+		chmod 600 "$cookieFile"
+}
+
 if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
 	# Check that we own everything in /opt/couchdb and fix if necessary. We also
 	# add the `-f` flag in all the following invocations because there may be
@@ -56,32 +91,41 @@ if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
 	touch /opt/couchdb/etc/local.d/docker.ini
 
 	if [ "$COUCHDB_USER" ] && [ "$COUCHDB_PASSWORD" ]; then
-		# Create admin only if not already present
-		if ! grep -Pzoqr "\[admins\]\n$COUCHDB_USER =" /opt/couchdb/etc/local.d/*.ini /opt/couchdb/etc/local.ini; then
-			printf "\n[admins]\n%s = %s\n" "$COUCHDB_USER" "$COUCHDB_PASSWORD" >> /opt/couchdb/etc/local.d/docker.ini
-		fi
+    set_admin_credentials "$COUCHDB_USER" "$COUCHDB_PASSWORD"
+  elif [ "$COUCHDB_USER_FILE" ] && [ "$COUCHDB_PASSWORD_FILE" ]; then
+    if [ -f "$COUCHDB_USER_FILE" ] && [ -f "$COUCHDB_PASSWORD_FILE" ]; then
+      adminUser=$(<"$COUCHDB_USER_FILE")
+      adminPassword=$(<"$COUCHDB_PASSWORD_FILE")
+      set_admin_credentials "$adminUser" "$adminPassword"
+    else
+      echo "ERROR: COUCHDB_USER_FILE or COUCHDB_PASSWORD_FILE does not exist." >&2
+      exit 1
+    fi
 	fi
 
 	if [ "$COUCHDB_SECRET" ]; then
 		# Set secret only if not already present
-		if ! grep -Pzoqr "\[chttpd_auth\]\nsecret =" /opt/couchdb/etc/local.d/*.ini /opt/couchdb/etc/local.ini; then
-			printf "\n[chttpd_auth]\nsecret = %s\n" "$COUCHDB_SECRET" >> /opt/couchdb/etc/local.d/docker.ini
-		fi
+		set_http_secret "$COUCHDB_SECRET"
+  elif [ "$COUCHDB_SECRET_FILE" ]; then
+    if [ -f "$COUCHDB_SECRET_FILE" ]; then
+      chttpSecret=$(<"$COUCHDB_SECRET_FILE")
+      set_http_secret "$chttpSecret"
+    else
+      echo "ERROR: COUCHDB_SECRET_FILE does not exist." >&2
+      exit 1
+    fi
 	fi
 
 	if [ "$COUCHDB_ERLANG_COOKIE" ]; then
-		cookieFile='/opt/couchdb/.erlang.cookie'
-		if [ -e "$cookieFile" ]; then
-			if [ "$(cat "$cookieFile" 2>/dev/null)" != "$COUCHDB_ERLANG_COOKIE" ]; then
-				echo >&2
-				echo >&2 "warning: $cookieFile contents do not match COUCHDB_ERLANG_COOKIE"
-				echo >&2
-			fi
-		else
-			echo "$COUCHDB_ERLANG_COOKIE" > "$cookieFile"
-		fi
-		chown couchdb:couchdb "$cookieFile"
-		chmod 600 "$cookieFile"
+    set_erlang_cookie "$COUCHDB_ERLANG_COOKIE"
+  elif [ "$COUCHDB_ERLANG_COOKIE_FILE" ]; then
+    if [ -f "$COUCHDB_ERLANG_COOKIE_FILE" ]; then
+      erlangCookie=$(<"$COUCHDB_ERLANG_COOKIE_FILE")
+      set_erlang_cookie "$erlangCookie"
+    else
+      echo "ERROR: COUCHDB_ERLANG_COOKIE_FILE does not exist." >&2
+      exit 1
+    fi
 	fi
 
 	chown -f couchdb:couchdb /opt/couchdb/etc/local.d/docker.ini || true


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Adds the ability to load secret values from files. These environment variables follow the existing environment variable names except with a `_FILE` suffix. 

- `COUCHDB_ERLANG_COOKIE_FILE`
- `COUCHDB_SECRET_FILE`
- `COUCHDB_USER_FILE`
- `COUCHDB_PASSWORD_FILE`

These environment variables are expected to be paths of projected secret values into the container. 

These environment variables are only used if the existing environment variables are not provided IE if a user specifies `COUCHDB_SECRET` then `COUCHDB_SECRET_FILE` will be ignored.

The existing logic of hydrating the docker.ini file has been extracted to functions and re-used with the values loaded from the secret files.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

TODO

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-docker/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

Fixes #256 

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
