### PR TITLE
Update docs

### DIFF
--- a/nouveau-compose/README.md
+++ b/nouveau-compose/README.md
@@ -4,8 +4,11 @@ standard `docker-compose.yml`.
 mkdir -p ./config/couchdb
 ```
 
-**./config/couchdb/nouveau.ini**
+**./config/couchdb/config.ini**
 ```ini
+[couchdb]
+single_node=true
+
 [nouveau]
 enable = true
 url = http://couchdb-nouveau:5987
@@ -16,18 +19,18 @@ url = http://couchdb-nouveau:5987
 ```yaml
 services:
   couchdb:
-    image: couchdb:3.4.1
+    image: couchdb:3.4
     restart: unless-stopped
     ports:
       - 5984:5984
     environment:
-      - ERL_FLAGS=-setcookie monster
-      - COUCHDB_CREATE_DATABASE=yes
+      - COUCHDB_USER=admin
+      - COUCHDB_PASSWORD=admin
     depends_on:
       - couchdb-nouveau
     volumes:
       - couchdb:/opt/couchdb/data
-      - ./config/couchdb/nouveau.ini:/opt/couchdb/etc/local.d/nouveau.ini
+      - ./config/couchdb/config.ini:/opt/couchdb/etc/local.d/config.ini
     healthcheck:
       test: ["CMD-SHELL", "curl --fail -s http://couchdb:5984/_up"]
       interval: 30s
@@ -35,14 +38,10 @@ services:
       retries: 5
 
   couchdb-nouveau:
-    image: couchdb:3.4.1-nouveau
+    image: couchdb:3.4-nouveau
 #    ports:
 #      - "5987:5987"
 #      - "5988:5988"
-
-networks:
-  default:
-    name: couchdb-net
 ```
 
 ```shell
@@ -51,5 +50,5 @@ docker-compose up
 
 Check it http://127.0.0.1:5984
 
-The _trick_ is the `./config/couchdb/nouveau.ini` defines the `couchdb-nouveau` to be running on docker network service named `couchdb-nouveau`. So the port (5987) mapped to the nouveau container.
+The _trick_ is the `./config/couchdb/config.ini` defines the `couchdb-nouveau` to be running on docker network service named `couchdb-nouveau`. So the port (5987) mapped to the nouveau container.
 


### PR DESCRIPTION
## Overview

Update the docs for some of the changes:
* Not sure when `COUCHDB_CREATE_DATABASE` disappeared, but I can't find anything using it
* Pretty sure `ERL_COOKIE` is a clouseau thing
* `COUCHDB_USER`/`COUCHDB_PASSWORD` have been required since the ~cops~good sense broke up the admin party

## Testing recommendations

Run the YAML

## Checklist

- [x] Documentation reflects the changes;
