### PR TITLE
fix(nouveau): Fixed server connector type

### DIFF
--- a/3.5.1-nouveau/nouveau.yaml
+++ b/3.5.1-nouveau/nouveau.yaml
@@ -8,12 +8,12 @@ logging:
 
 server:
   applicationConnectors:
-    - type: http
+    - type: h2c
       bindHost: 0.0.0.0
       port: 5987
       useDateHeader: false
   adminConnectors:
-    - type: http
+    - type: h2c
       bindHost: 0.0.0.0
       port: 5988
       useDateHeader: false


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

While working with the docker images of `couchdb` and `couchdb-nouveau`, we encountered connector type errors. I've attached the error logs here :

From `couchdb_container` :

```
couchdb_container  | [error] 2026-04-01T11:28:02.955614Z nonode@nohost <0.548.0> -------- nouveau_index_manager: db:sw360db ddoc:_design/lucene index:projects failed with: {error,{connection_error,{protocol_error,'Invalid connection preface received. Appears to be an HTTP/1 response? (RFC7540 3.5)'}}}
couchdb_container  | [error] 2026-04-01T11:28:02.956357Z nonode@nohost <0.548.0> -------- nouveau_index_manager: db:sw360db ddoc:_design/lucene index:components failed with: {error,{connection_error,{protocol_error,'Invalid connection preface received. Appears to be an HTTP/1 response? (RFC7540 3.5)'}}}
couchdb_container  | [error] 2026-04-01T11:28:02.956767Z nonode@nohost <0.548.0> -------- nouveau_index_manager: db:sw360db ddoc:_design/lucene index:obligations failed with: {error,{connection_error,{protocol_error,'Invalid connection preface received. Appears to be an HTTP/1 response? (RFC7540 3.5)'}}}
couchdb_container  | [error] 2026-04-01T11:28:02.957136Z nonode@nohost <0.548.0> -------- nouveau_index_manager: db:sw360db ddoc:_design/lucene index:releases failed with: {error,{connection_error,{protocol_error,'Invalid connection preface received. Appears to be an HTTP/1 response? (RFC7540 3.5)'}}}
```

Then on the official documentation of `couchdb-nouveau` [ installation guide ](https://docs.couchdb.org/en/stable/install/nouveau.html#configuring-nouveau-to-authenticate-clients) also, we found :
```
in nouveau.yaml you should remove all connectors of type h2c and add new ones using h2;
```

We found it mentions about `h2c` and `h2` as connection type for the server, which is `HTTP/2`.
 
The default server mentions `http` which is `version 1` and causing the issue as `CouchDB` is expecting `HTTP/2`.
 
Changing `http` to `h2c` in the `nouveau.yaml` for the image, the connection started working.

Here is the log from updated `couchdb_nouveau_container` with connector type as `h2c` 

```
couchdb_nouveau_container  | INFO  [2026-04-01 11:31:50,320] org.eclipse.jetty.server.handler.ContextHandler: Started i.d.j.MutableServletContextHandler@4b862408{/,null,AVAILABLE}
couchdb_nouveau_container  | INFO  [2026-04-01 11:31:50,324] org.eclipse.jetty.server.AbstractConnector: Started application@3ffb3598{HTTP/1.1, (http/1.1, h2c)}{0.0.0.0:5987}
couchdb_nouveau_container  | INFO  [2026-04-01 11:31:50,325] org.eclipse.jetty.server.AbstractConnector: Started admin@4da9f723{HTTP/1.1, (http/1.1, h2c)}{0.0.0.0:5988}
couchdb_nouveau_container  | INFO  [2026-04-01 11:31:50,326] org.eclipse.jetty.server.Server: Started Server@3cbf1ba4{STARTING}[11.0.24,sto=30000] @1369ms
```

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
